### PR TITLE
feat(styles): add semantic css variables (COL-001)

### DIFF
--- a/.agents/issues/ISSUES.md
+++ b/.agents/issues/ISSUES.md
@@ -4,8 +4,8 @@
 
 **Ultima actualizacion:** 2026-02-05
 **Total issues:** 32
-**Completados:** 0
-**Pendientes:** 32
+**Completados:** 1
+**Pendientes:** 31
 
 ---
 
@@ -13,7 +13,7 @@
 
 | Categoria | Total | Completados | Pendientes | GitHub Issues |
 |-----------|-------|-------------|------------|---------------|
-| Colores Hardcodeados | 8 | 0 | 8 | #30-#37 |
+| Colores Hardcodeados | 8 | 1 | 7 | #30-#37 |
 | Codigo Duplicado | 15 | 0 | 15 | Pendiente crear |
 | Accesibilidad | 6 | 0 | 6 | Pendiente crear |
 | Consistencia de Diseno | 3 | 0 | 3 | Pendiente crear |
@@ -23,7 +23,7 @@
 ## ISSUES DE COLORES HARDCODEADOS
 
 ### COL-001: Agregar variables CSS semanticas al sistema de diseno
-- **Estado:** `[ ] Pendiente`
+- **Estado:** `[x] Completado`
 - **GitHub:** [#30](https://github.com/JhonK-Dev/epg-portal-web/issues/30)
 - **Prioridad:** Alta
 - **Archivo:** `src/styles/global.css`
@@ -410,5 +410,6 @@
 | Fecha | Issue | Accion | Notas |
 |-------|-------|--------|-------|
 | 2026-02-05 | - | Creacion inicial | 32 issues identificados |
+| 2026-02-05 | COL-001 | Completado | Agregadas variables CSS semanticas en global.css |
 | 2026-02-05 | COL-001 a COL-008 | Creados en GitHub | Issues #30-#37 creados |
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,6 +41,18 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  /* Colores Semánticos */
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  /* Colores de Programa */
+  --color-maestria: var(--maestria);
+  --color-doctorado: var(--doctorado);
+  --color-diplomado: var(--diplomado);
+  --color-curso: var(--curso);
   /* Colores institucionales EPG UNAP */
   --color-epg-navy: #0A1628;
   --color-epg-navy-light: #0D2240;
@@ -85,6 +97,18 @@
   --sidebar-accent-foreground: #ffffff;
   --sidebar-border: #060D17;
   --sidebar-ring: #D4A017;
+  /* Colores Semánticos */
+  --success: #22c55e;
+  --success-foreground: #ffffff;
+  --warning: #f59e0b;
+  --warning-foreground: #000000;
+  --info: #3b82f6;
+  --info-foreground: #ffffff;
+  /* Colores de Programa */
+  --maestria: #2563eb;
+  --doctorado: #9333ea;
+  --diplomado: #059669;
+  --curso: #d97706;
 }
 
 .dark {
@@ -120,6 +144,18 @@
   --sidebar-accent-foreground: #f5f5f5;
   --sidebar-border: #374151;
   --sidebar-ring: #D4A017;
+  /* Colores Semánticos (Dark Mode) */
+  --success: #22c55e;
+  --success-foreground: #ffffff;
+  --warning: #f59e0b;
+  --warning-foreground: #000000;
+  --info: #3b82f6;
+  --info-foreground: #ffffff;
+  /* Colores de Programa (Dark Mode) */
+  --maestria: #2563eb;
+  --doctorado: #9333ea;
+  --diplomado: #059669;
+  --curso: #d97706;
 }
 
 @layer base {


### PR DESCRIPTION
## Descripción
Este PR implementa las variables CSS semánticas solicitadas en el issue COL-001.

## Cambios
- Agregadas variables semánticas (`--success`, `--warning`, `--info`)
- Agregadas variables de tipos de programa (`--maestria`, `--doctorado`, `--diplomado`, `--curso`)
- Mapeadas todas las variables en `@theme inline` para uso con Tailwind
- Definidas en `:root` y `.dark`

## Issue Relacionado
Closes #30

## Verificación
- [x] Variables agregadas en `src/styles/global.css`
- [x] Soporte para modo oscuro
- [x] Compatibilidad con Tailwind v4