### PR TITLE
fix(design-system): COL-004 - Reemplazar bg-green-400 en AdmissionCTA

### DIFF
--- a/src/features/home/components/AdmissionCTA.tsx
+++ b/src/features/home/components/AdmissionCTA.tsx
@@ -15,7 +15,7 @@ export const AdmissionCTA: React.FC = () => {
           {/* Left Content */}
           <div>
             <div className="inline-flex items-center gap-2 bg-epg-navy text-white px-4 py-2 rounded-full text-sm font-medium mb-6">
-              <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+              <span className="w-2 h-2 bg-success rounded-full animate-pulse" />
               Convocatoria abierta
             </div>
 


### PR DESCRIPTION
## Summary

- Reemplaza `bg-green-400` hardcodeado por variable semántica `bg-success` en `AdmissionCTA.tsx`
- El cambio afecta el indicador de estado pulsante "Convocatoria abierta"

## Issue

Closes #33

## Cambios

| Línea | Antes | Después |
|-------|-------|---------|
| 18 | `bg-green-400` | `bg-success` |

## Testing

- ✅ Build exitoso (43 páginas)
- ✅ El indicador de estado mantiene su apariencia visual