### PR TITLE
fix(design-system): COL-005 - Reemplazar bg-red-500 en ServiciosGrid

### DIFF
--- a/src/features/servicios/components/ServiciosGrid.tsx
+++ b/src/features/servicios/components/ServiciosGrid.tsx
@@ -131,7 +131,7 @@ export function ServiciosGrid() {
           <Card className="bg-gray-50 border-0">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-red-500 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-12 h-12 bg-destructive rounded-lg flex items-center justify-center flex-shrink-0">
                   <Phone className="h-6 w-6 text-white" />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary

- Reemplaza `bg-red-500` hardcodeado por variable semántica `bg-destructive` en `ServiciosGrid.tsx`
- El cambio afecta el ícono de la sección "Problemas de Acceso"
- El color rojo tiene propósito semántico (indica alerta/problema), por lo que `bg-destructive` es apropiado

## Issue

Closes #34

## Cambios

| Línea | Antes | Después |
|-------|-------|---------|
| 134 | `bg-red-500` | `bg-destructive` |

## Análisis

El color rojo se usa en el contexto de "Problemas de Acceso" - una sección de soporte para usuarios con dificultades técnicas. El significado semántico es de alerta/problema, lo cual corresponde correctamente a la variable `destructive`.

## Testing

- ✅ Build exitoso (43 páginas)
- ✅ Verificación visual del componente