### PR TITLE
fix(design-system): COL-006 - Reemplazar colores destructivos en ProgramasLista

### DIFF
--- a/src/features/programas/components/ProgramasLista.tsx
+++ b/src/features/programas/components/ProgramasLista.tsx
@@ -281,7 +281,7 @@ export function ProgramasLista() {
               variant="ghost"
               size="sm"
               onClick={limpiarFiltros}
-              className="text-red-600 hover:text-red-700 hover:bg-red-50"
+              className="text-destructive hover:text-destructive/80 hover:bg-destructive/10"
             >
               Limpiar todo
             </Button>


### PR DESCRIPTION
## Summary

- Reemplaza colores red hardcodeados por variables semánticas `destructive` en `ProgramasLista.tsx`
- Afecta el botón "Limpiar todo" en la sección de filtros activos

## Issue

Closes #35

## Cambios

| Línea | Antes | Después |
|-------|-------|---------|
| 284 | `text-red-600 hover:text-red-700 hover:bg-red-50` | `text-destructive hover:text-destructive/80 hover:bg-destructive/10` |

## Análisis

El botón "Limpiar todo" es una acción que elimina/borra los filtros aplicados. El uso de `destructive` es semánticamente correcto para este tipo de acciones.

## Testing

- ✅ Build exitoso (43 páginas)
- ✅ Estados hover funcionan correctamente con opacidad