### PR TITLE
feat(ui): extract FilterTabs component for reusability

### DIFF
--- a/src/components/ui/filter-tabs.tsx
+++ b/src/components/ui/filter-tabs.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface FilterTab {
+  /** Unique identifier for the tab */
+  id: string
+  /** Display label for the tab */
+  label: string
+  /** Optional icon to display before the label */
+  icon?: React.ReactNode
+  /** Optional count to display in a badge */
+  count?: number
+}
+
+export interface FilterTabsProps {
+  /** Array of tab configurations */
+  tabs: FilterTab[]
+  /** ID of the currently active tab */
+  activeTab: string
+  /** Callback when a tab is clicked */
+  onTabChange: (tabId: string) => void
+  /** Visual style variant */
+  variant?: 'pill' | 'rounded'
+  /** Additional className for the container */
+  className?: string
+}
+
+/**
+ * FilterTabs - A reusable tabs component with optional icons and count badges.
+ *
+ * @example
+ * // Basic usage with pill variant
+ * <FilterTabs
+ *   tabs={[
+ *     { id: 'todas', label: 'Todas', count: 10 },
+ *     { id: 'noticias', label: 'Noticias', icon: <Icon />, count: 5 }
+ *   ]}
+ *   activeTab={activeTab}
+ *   onTabChange={setActiveTab}
+ * />
+ *
+ * @example
+ * // With rounded variant
+ * <FilterTabs
+ *   tabs={tabs}
+ *   activeTab={filtro}
+ *   onTabChange={setFiltro}
+ *   variant="rounded"
+ * />
+ */
+export function FilterTabs({
+  tabs,
+  activeTab,
+  onTabChange,
+  variant = 'pill',
+  className,
+}: FilterTabsProps) {
+  const baseButtonClasses =
+    'flex items-center gap-2 px-4 py-2 text-sm font-medium whitespace-nowrap transition-all'
+
+  const variantClasses = {
+    pill: 'rounded-full',
+    rounded: 'rounded-lg',
+  }
+
+  const activeClasses = 'bg-epg-navy text-white'
+  const inactiveClasses = 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+
+  return (
+    <div
+      className={cn('flex overflow-x-auto gap-2 pb-2 lg:pb-0', className)}
+      role="tablist"
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={cn(
+            baseButtonClasses,
+            variantClasses[variant],
+            activeTab === tab.id ? activeClasses : inactiveClasses,
+          )}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          aria-controls={`tabpanel-${tab.id}`}
+        >
+          {tab.icon && tab.icon}
+          {tab.label}
+          {tab.count !== undefined && (
+            <span
+              className={cn(
+                'ml-1 text-xs px-2 py-0.5 rounded-full',
+                activeTab === tab.id ? 'bg-white/20' : 'bg-gray-200',
+              )}
+            >
+              {tab.count}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default FilterTabs

--- a/src/features/docentes/components/DocentesGrid.tsx
+++ b/src/features/docentes/components/DocentesGrid.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CTABannerSideBySide } from '@/components/ui/cta-banner'
 import { SearchInput } from '@/components/ui/search-input'
+import { FilterTabs } from '@/components/ui/filter-tabs'
 
 type FiltroGrado = 'todos' | 'doctores' | 'magisteres'
 
@@ -72,29 +73,17 @@ export function DocentesGrid() {
       {/* Filtros */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         {/* Tabs */}
-        <div className="flex gap-2">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setFiltroGrado(tab.id)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
-                filtroGrado === tab.id
-                  ? 'bg-epg-navy text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              }`}
-            >
-              {tab.icon}
-              {tab.label}
-              <span
-                className={`ml-1 text-xs px-2 py-0.5 rounded-full ${
-                  filtroGrado === tab.id ? 'bg-white/20' : 'bg-gray-200'
-                }`}
-              >
-                {conteos[tab.id]}
-              </span>
-            </button>
-          ))}
-        </div>
+        <FilterTabs
+          tabs={tabs.map((tab) => ({
+            id: tab.id,
+            label: tab.label,
+            icon: tab.icon,
+            count: conteos[tab.id],
+          }))}
+          activeTab={filtroGrado}
+          onTabChange={(id) => setFiltroGrado(id as FiltroGrado)}
+          variant="rounded"
+        />
 
         {/* Búsqueda */}
         <SearchInput

--- a/src/features/publicaciones/components/PublicacionesLista.tsx
+++ b/src/features/publicaciones/components/PublicacionesLista.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { SearchInput } from '@/components/ui/search-input'
+import { FilterTabs } from '@/components/ui/filter-tabs'
 import { NewsletterForm } from '@/features/contacto'
 
 type TipoPublicacion = 'todas' | 'noticia' | 'evento' | 'aviso' | 'comunicado'
@@ -119,29 +120,17 @@ export function PublicacionesLista() {
       {/* Tabs y Búsqueda */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         {/* Tabs */}
-        <div className="flex overflow-x-auto gap-2 pb-2 lg:pb-0">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setTipoActivo(tab.id)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-all ${
-                tipoActivo === tab.id
-                  ? 'bg-epg-navy text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              }`}
-            >
-              {tab.icon}
-              {tab.label}
-              <span
-                className={`ml-1 text-xs px-2 py-0.5 rounded-full ${
-                  tipoActivo === tab.id ? 'bg-white/20' : 'bg-gray-200'
-                }`}
-              >
-                {conteos[tab.id]}
-              </span>
-            </button>
-          ))}
-        </div>
+        <FilterTabs
+          tabs={tabs.map((tab) => ({
+            id: tab.id,
+            label: tab.label,
+            icon: tab.icon,
+            count: conteos[tab.id],
+          }))}
+          activeTab={tipoActivo}
+          onTabChange={(id) => setTipoActivo(id as TipoPublicacion)}
+          variant="pill"
+        />
 
         {/* Búsqueda */}
         <SearchInput


### PR DESCRIPTION
- Create src/components/ui/filter-tabs.tsx with props:
  - tabs, activeTab, onTabChange, variant
  - Supports pill and rounded variants
  - Includes optional icons and count badges
  - Fully accessible with ARIA attributes
- Refactor PublicacionesLista.tsx to use FilterTabs (pill variant)
- Refactor DocentesGrid.tsx to use FilterTabs (rounded variant)

Reduces ~80 lines of duplicated code and standardizes tab navigation across the application.

Closes #51