### PR TITLE
feat: Extract PageHero component to eliminate duplication

### DIFF
--- a/src/components/ui/page-hero.tsx
+++ b/src/components/ui/page-hero.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { Badge } from './badge'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+export interface PageHeroProps {
+  /** Breadcrumb navigation items */
+  breadcrumbs: BreadcrumbItem[]
+  /** Main page title */
+  title: string
+  /** Optional subtitle/description */
+  subtitle?: string
+  /** Optional badge to display */
+  badge?: {
+    label: string
+    variant?: 'default' | 'secondary' | 'outline' | 'destructive'
+    className?: string
+    icon?: React.ReactNode
+  }
+  /** Additional content to render in the hero */
+  children?: React.ReactNode
+  /** Visual variant for the hero background */
+  variant?: 'solid' | 'gradient'
+  /** Custom background color classes (overrides variant) */
+  bgColorClass?: string
+  /** Additional className for the hero container */
+  className?: string
+}
+
+/**
+ * PageHero - A reusable hero component for page headers with breadcrumbs.
+ *
+ * @example
+ * // Basic usage with solid background
+ * <PageHero
+ *   breadcrumbs={[
+ *     { label: 'Inicio', href: '/' },
+ *     { label: 'Programas', href: '/programas' },
+ *     { label: 'Maestrías' }
+ *   ]}
+ *   title="Maestría en Gestión Pública"
+ *   subtitle="Programa de postgrado orientado a la gestión pública moderna"
+ *   badge={{ label: 'Maestría', variant: 'outline' }}
+ *   variant="solid"
+ *   bgColorClass="bg-blue-600"
+ * />
+ *
+ * @example
+ * // With gradient and custom content
+ * <PageHero
+ *   breadcrumbs={[...]}
+ *   title="Portal del Estudiante"
+ *   subtitle="Accede a recursos y servicios exclusivos"
+ *   variant="gradient"
+ * >
+ *   <div className="mt-6">
+ *     <Button>Acción rápida</Button>
+ *   </div>
+ * </PageHero>
+ */
+export function PageHero({
+  breadcrumbs,
+  title,
+  subtitle,
+  badge,
+  children,
+  variant = 'gradient',
+  bgColorClass,
+  className,
+}: PageHeroProps) {
+  // Determine background class
+  const bgClass =
+    bgColorClass ||
+    (variant === 'gradient'
+      ? 'bg-gradient-to-br from-epg-navy to-epg-navy-light'
+      : 'bg-epg-navy')
+
+  return (
+    <div className={cn(bgClass, 'text-white', className)}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Breadcrumb */}
+        <nav className="text-sm mb-6" aria-label="Breadcrumb">
+          <ol className="flex items-center gap-2">
+            {breadcrumbs.map((item, index) => {
+              const isLast = index === breadcrumbs.length - 1
+
+              return (
+                <React.Fragment key={index}>
+                  {index > 0 && (
+                    <li className="text-gray-400" aria-hidden="true">
+                      /
+                    </li>
+                  )}
+                  <li>
+                    {item.href ? (
+                      <a
+                        href={item.href}
+                        className="text-gray-300 hover:text-white transition-colors"
+                      >
+                        {item.label}
+                      </a>
+                    ) : (
+                      <span className={isLast ? 'text-epg-gold' : 'text-white'}>
+                        {item.label}
+                      </span>
+                    )}
+                  </li>
+                </React.Fragment>
+              )
+            })}
+          </ol>
+        </nav>
+
+        {/* Badge */}
+        {badge && (
+          <div className="mb-4">
+            <Badge
+              variant={badge.variant}
+              className={cn(
+                'bg-white/20 text-white hover:bg-white/30 gap-1',
+                badge.className,
+              )}
+            >
+              {badge.icon}
+              {badge.label}
+            </Badge>
+          </div>
+        )}
+
+        {/* Title */}
+        <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 leading-tight">
+          {title}
+        </h1>
+
+        {/* Subtitle */}
+        {subtitle && (
+          <p className="text-lg md:text-xl text-gray-300 max-w-3xl">
+            {subtitle}
+          </p>
+        )}
+
+        {/* Custom content */}
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default PageHero

--- a/src/features/docentes/components/DocenteDetail.tsx
+++ b/src/features/docentes/components/DocenteDetail.tsx
@@ -1,6 +1,6 @@
-import type { Docente } from '@/types';
-import { getProgramaById } from '@/data/programas';
-import { getGradoInfo, getSocialNetworkClasses } from '@/lib/constants';
+import type { Docente } from '@/types'
+import { getProgramaById } from '@/data/programas'
+import { getGradoInfo, getSocialNetworkClasses } from '@/lib/constants'
 import {
   Mail,
   Phone,
@@ -17,138 +17,131 @@ import {
   Calendar,
   Users,
   Building2,
-  Globe
-} from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
+  Globe,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { PageHero } from '@/components/ui/page-hero'
 
 interface DocenteDetailProps {
-  docente: Docente;
+  docente: Docente
 }
 
 export function DocenteDetail({ docente }: DocenteDetailProps) {
-  const gradoInfo = getGradoInfo(docente.grado);
-  const nombreCompleto = `${gradoInfo.label} ${docente.nombres} ${docente.apellidos}`;
-  
+  const gradoInfo = getGradoInfo(docente.grado)
+  const nombreCompleto = `${gradoInfo.label} ${docente.nombres} ${docente.apellidos}`
+
   // Get programs where this teacher teaches
-  const programasDocente = docente.programas?.map(id => getProgramaById(id)).filter(Boolean) || [];
+  const programasDocente =
+    docente.programas?.map((id) => getProgramaById(id)).filter(Boolean) || []
 
   return (
     <div>
       {/* Hero Section */}
-      <section className="bg-gradient-to-br from-epg-navy to-epg-navy-light text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Breadcrumb */}
-          <nav className="text-sm mb-6">
-            <ol className="flex items-center gap-2">
-              <li><a href="/" className="text-gray-300 hover:text-white">Inicio</a></li>
-              <li className="text-gray-400">/</li>
-              <li><a href="/docentes" className="text-gray-300 hover:text-white">Docentes</a></li>
-              <li className="text-gray-400">/</li>
-              <li className="text-epg-gold">{docente.apellidos}</li>
-            </ol>
-          </nav>
+      <PageHero
+        breadcrumbs={[
+          { label: 'Inicio', href: '/' },
+          { label: 'Docentes', href: '/docentes' },
+          { label: docente.apellidos },
+        ]}
+        title={nombreCompleto}
+        subtitle={docente.resumenPerfil}
+        badge={{
+          label: gradoInfo.labelFull,
+          className: `${gradoInfo.bgColor} ${gradoInfo.color}`,
+        }}
+        variant="gradient"
+      >
+        <div className="flex flex-col lg:flex-row gap-8 items-start mt-6">
+          {/* Avatar */}
+          <div className="flex-shrink-0">
+            <div className="w-40 h-40 lg:w-48 lg:h-48 rounded-2xl bg-white/10 flex items-center justify-center text-white text-5xl lg:text-6xl font-bold border-4 border-epg-gold/30">
+              {docente.nombres.charAt(0)}
+              {docente.apellidos.charAt(0)}
+            </div>
+          </div>
 
-          <div className="flex flex-col lg:flex-row gap-8 items-start">
-            {/* Avatar */}
-            <div className="flex-shrink-0">
-              <div className="w-40 h-40 lg:w-48 lg:h-48 rounded-2xl bg-white/10 flex items-center justify-center text-white text-5xl lg:text-6xl font-bold border-4 border-epg-gold/30">
-                {docente.nombres.charAt(0)}{docente.apellidos.charAt(0)}
-              </div>
+          {/* Info */}
+          <div className="flex-1">
+            <p className="text-xl text-epg-gold mb-4">{docente.especialidad}</p>
+
+            {/* Contact Links */}
+            <div className="flex flex-wrap gap-3">
+              {docente.email && (
+                <a
+                  href={`mailto:${docente.email}`}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 rounded-lg hover:bg-white/20 transition-colors"
+                >
+                  <Mail className="w-4 h-4" />
+                  <span className="text-sm">{docente.email}</span>
+                </a>
+              )}
+              {docente.telefono && (
+                <a
+                  href={`tel:${docente.telefono}`}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 rounded-lg hover:bg-white/20 transition-colors"
+                >
+                  <Phone className="w-4 h-4" />
+                  <span className="text-sm">{docente.telefono}</span>
+                </a>
+              )}
             </div>
 
-            {/* Info */}
-            <div className="flex-1">
-              <Badge className={`${gradoInfo.bgColor} ${gradoInfo.color} mb-3`}>
-                {gradoInfo.labelFull}
-              </Badge>
-              <h1 className="text-3xl lg:text-4xl font-bold mb-2">{nombreCompleto}</h1>
-              <p className="text-xl text-epg-gold mb-4">{docente.especialidad}</p>
-              
-              {docente.resumenPerfil && (
-                <p className="text-gray-300 text-lg max-w-3xl mb-6">
-                  {docente.resumenPerfil}
-                </p>
+            {/* Academic Links */}
+            <div className="flex flex-wrap gap-3 mt-4">
+              {docente.orcid && (
+                <a
+                  href={`https://orcid.org/${docente.orcid}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('orcid')}`}
+                >
+                  <Globe className="w-4 h-4" />
+                  ORCID
+                  <ExternalLink className="w-3 h-3" />
+                </a>
               )}
-
-              {/* Contact Links */}
-              <div className="flex flex-wrap gap-3">
-                {docente.email && (
-                  <a
-                    href={`mailto:${docente.email}`}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 rounded-lg hover:bg-white/20 transition-colors"
-                  >
-                    <Mail className="w-4 h-4" />
-                    <span className="text-sm">{docente.email}</span>
-                  </a>
-                )}
-                {docente.telefono && (
-                  <a
-                    href={`tel:${docente.telefono}`}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 rounded-lg hover:bg-white/20 transition-colors"
-                  >
-                    <Phone className="w-4 h-4" />
-                    <span className="text-sm">{docente.telefono}</span>
-                  </a>
-                )}
-              </div>
-
-              {/* Academic Links */}
-              <div className="flex flex-wrap gap-3 mt-4">
-{docente.orcid && (
-                  <a
-                    href={`https://orcid.org/${docente.orcid}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('orcid')}`}
-                  >
-                    <Globe className="w-4 h-4" />
-                    ORCID
-                    <ExternalLink className="w-3 h-3" />
-                  </a>
-                )}
-                {docente.googleScholar && (
-                  <a
-                    href={docente.googleScholar}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('googleScholar')}`}
-                  >
-                    <BookOpen className="w-4 h-4" />
-                    Google Scholar
-                    <ExternalLink className="w-3 h-3" />
-                  </a>
-                )}
-                {docente.linkedin && (
-                  <a
-                    href={docente.linkedin}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('linkedin')}`}
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                    LinkedIn
-                  </a>
-                )}
-                {docente.researchgate && (
-                  <a
-                    href={docente.researchgate}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('researchGate')}`}
-                  >
-                    <BookOpen className="w-4 h-4" />
-                    ResearchGate
-                    <ExternalLink className="w-3 h-3" />
-                  </a>
-                )}
-              </div>
+              {docente.googleScholar && (
+                <a
+                  href={docente.googleScholar}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('googleScholar')}`}
+                >
+                  <BookOpen className="w-4 h-4" />
+                  Google Scholar
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+              {docente.linkedin && (
+                <a
+                  href={docente.linkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('linkedin')}`}
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  LinkedIn
+                </a>
+              )}
+              {docente.researchgate && (
+                <a
+                  href={docente.researchgate}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors text-sm ${getSocialNetworkClasses('researchGate')}`}
+                >
+                  <BookOpen className="w-4 h-4" />
+                  ResearchGate
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
             </div>
           </div>
         </div>
-      </section>
+      </PageHero>
 
       {/* Content Section */}
       <section className="py-12">
@@ -166,183 +159,212 @@ export function DocenteDetail({ docente }: DocenteDetailProps) {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600 leading-relaxed">{docente.biografia}</p>
+                    <p className="text-gray-600 leading-relaxed">
+                      {docente.biografia}
+                    </p>
                   </CardContent>
                 </Card>
               )}
 
               {/* Áreas de Investigación */}
-              {docente.areasInvestigacion && docente.areasInvestigacion.length > 0 && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Lightbulb className="w-5 h-5 text-epg-gold" />
-                      Áreas de Investigación
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex flex-wrap gap-2">
-                      {docente.areasInvestigacion.map((area, index) => (
-                        <Badge key={index} variant="secondary" className="bg-epg-gold/10 text-epg-navy">
-                          {area}
-                        </Badge>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+              {docente.areasInvestigacion &&
+                docente.areasInvestigacion.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <Lightbulb className="w-5 h-5 text-epg-gold" />
+                        Áreas de Investigación
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex flex-wrap gap-2">
+                        {docente.areasInvestigacion.map((area, index) => (
+                          <Badge
+                            key={index}
+                            variant="secondary"
+                            className="bg-epg-gold/10 text-epg-navy"
+                          >
+                            {area}
+                          </Badge>
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
 
               {/* Formación Académica */}
-              {docente.formacionAcademica && docente.formacionAcademica.length > 0 && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <GraduationCap className="w-5 h-5 text-epg-gold" />
-                      Formación Académica
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      {docente.formacionAcademica.map((formacion, index) => (
-                        <div key={index} className="flex gap-4 items-start">
-                          <div className="w-10 h-10 bg-epg-navy rounded-full flex items-center justify-center flex-shrink-0">
-                            <GraduationCap className="w-5 h-5 text-white" />
-                          </div>
-                          <div>
-                            <h4 className="font-semibold text-epg-navy">{formacion.grado}</h4>
-                            <p className="text-gray-600">{formacion.institucion}</p>
-                            <div className="flex items-center gap-2 text-sm text-gray-500 mt-1">
-                              <MapPin className="w-3 h-3" />
-                              <span>{formacion.pais}</span>
-                              <span>•</span>
-                              <Calendar className="w-3 h-3" />
-                              <span>{formacion.anio}</span>
+              {docente.formacionAcademica &&
+                docente.formacionAcademica.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <GraduationCap className="w-5 h-5 text-epg-gold" />
+                        Formación Académica
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-4">
+                        {docente.formacionAcademica.map((formacion, index) => (
+                          <div key={index} className="flex gap-4 items-start">
+                            <div className="w-10 h-10 bg-epg-navy rounded-full flex items-center justify-center flex-shrink-0">
+                              <GraduationCap className="w-5 h-5 text-white" />
+                            </div>
+                            <div>
+                              <h4 className="font-semibold text-epg-navy">
+                                {formacion.grado}
+                              </h4>
+                              <p className="text-gray-600">
+                                {formacion.institucion}
+                              </p>
+                              <div className="flex items-center gap-2 text-sm text-gray-500 mt-1">
+                                <MapPin className="w-3 h-3" />
+                                <span>{formacion.pais}</span>
+                                <span>•</span>
+                                <Calendar className="w-3 h-3" />
+                                <span>{formacion.anio}</span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
 
               {/* Experiencia Profesional */}
-              {docente.experienciaProfesional && docente.experienciaProfesional.length > 0 && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Briefcase className="w-5 h-5 text-epg-gold" />
-                      Experiencia Profesional
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      {docente.experienciaProfesional.map((exp, index) => (
-                        <div key={index} className="flex gap-4 items-start">
-                          <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0">
-                            <Building2 className="w-5 h-5 text-blue-600" />
-                          </div>
-                          <div className="flex-1">
-                            <h4 className="font-semibold text-epg-navy">{exp.cargo}</h4>
-                            <p className="text-gray-600">{exp.institucion}</p>
-                            <div className="flex items-center gap-2 text-sm text-gray-500 mt-1">
-                              <Calendar className="w-3 h-3" />
-                              <span>{exp.periodo}</span>
+              {docente.experienciaProfesional &&
+                docente.experienciaProfesional.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <Briefcase className="w-5 h-5 text-epg-gold" />
+                        Experiencia Profesional
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-4">
+                        {docente.experienciaProfesional.map((exp, index) => (
+                          <div key={index} className="flex gap-4 items-start">
+                            <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0">
+                              <Building2 className="w-5 h-5 text-blue-600" />
                             </div>
-                            {exp.descripcion && (
-                              <p className="text-sm text-gray-500 mt-2">{exp.descripcion}</p>
-                            )}
+                            <div className="flex-1">
+                              <h4 className="font-semibold text-epg-navy">
+                                {exp.cargo}
+                              </h4>
+                              <p className="text-gray-600">{exp.institucion}</p>
+                              <div className="flex items-center gap-2 text-sm text-gray-500 mt-1">
+                                <Calendar className="w-3 h-3" />
+                                <span>{exp.periodo}</span>
+                              </div>
+                              {exp.descripcion && (
+                                <p className="text-sm text-gray-500 mt-2">
+                                  {exp.descripcion}
+                                </p>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
 
               {/* Publicaciones */}
-              {docente.publicacionesAcademicas && docente.publicacionesAcademicas.length > 0 && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <FileText className="w-5 h-5 text-epg-gold" />
-                      Publicaciones Académicas
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      {docente.publicacionesAcademicas.map((pub, index) => (
-                        <div key={index} className="p-4 bg-gray-50 rounded-lg">
-                          <h4 className="font-medium text-epg-navy mb-1">{pub.titulo}</h4>
-                          <p className="text-sm text-gray-600">
-                            <span className="font-medium">{pub.revista}</span>
-                            <span className="mx-2">•</span>
-                            <span>{pub.anio}</span>
-                          </p>
-                          {pub.doi && (
-                            <a
-                              href={`https://doi.org/${pub.doi}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline mt-2"
-                            >
-                              DOI: {pub.doi}
-                              <ExternalLink className="w-3 h-3" />
-                            </a>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+              {docente.publicacionesAcademicas &&
+                docente.publicacionesAcademicas.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <FileText className="w-5 h-5 text-epg-gold" />
+                        Publicaciones Académicas
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-4">
+                        {docente.publicacionesAcademicas.map((pub, index) => (
+                          <div
+                            key={index}
+                            className="p-4 bg-gray-50 rounded-lg"
+                          >
+                            <h4 className="font-medium text-epg-navy mb-1">
+                              {pub.titulo}
+                            </h4>
+                            <p className="text-sm text-gray-600">
+                              <span className="font-medium">{pub.revista}</span>
+                              <span className="mx-2">•</span>
+                              <span>{pub.anio}</span>
+                            </p>
+                            {pub.doi && (
+                              <a
+                                href={`https://doi.org/${pub.doi}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline mt-2"
+                              >
+                                DOI: {pub.doi}
+                                <ExternalLink className="w-3 h-3" />
+                              </a>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
 
               {/* Proyectos de Investigación */}
-              {docente.proyectosInvestigacion && docente.proyectosInvestigacion.length > 0 && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Lightbulb className="w-5 h-5 text-epg-gold" />
-                      Proyectos de Investigación
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <ul className="space-y-2">
-                      {docente.proyectosInvestigacion.map((proyecto, index) => (
-                        <li key={index} className="flex items-start gap-2">
-                          <div className="w-2 h-2 bg-epg-gold rounded-full mt-2 flex-shrink-0" />
-                          <span className="text-gray-600">{proyecto}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                </Card>
-              )}
+              {docente.proyectosInvestigacion &&
+                docente.proyectosInvestigacion.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <Lightbulb className="w-5 h-5 text-epg-gold" />
+                        Proyectos de Investigación
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <ul className="space-y-2">
+                        {docente.proyectosInvestigacion.map(
+                          (proyecto, index) => (
+                            <li key={index} className="flex items-start gap-2">
+                              <div className="w-2 h-2 bg-epg-gold rounded-full mt-2 flex-shrink-0" />
+                              <span className="text-gray-600">{proyecto}</span>
+                            </li>
+                          ),
+                        )}
+                      </ul>
+                    </CardContent>
+                  </Card>
+                )}
             </div>
 
             {/* Sidebar */}
             <div className="space-y-6">
               {/* Reconocimientos */}
-              {docente.reconocimientos && docente.reconocimientos.length > 0 && (
-                <Card className="bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200">
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 text-amber-800">
-                      <Award className="w-5 h-5" />
-                      Reconocimientos
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <ul className="space-y-3">
-                      {docente.reconocimientos.map((rec, index) => (
-                        <li key={index} className="flex items-start gap-2">
-                          <Star className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
-                          <span className="text-sm text-amber-900">{rec}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                </Card>
-              )}
+              {docente.reconocimientos &&
+                docente.reconocimientos.length > 0 && (
+                  <Card className="bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2 text-amber-800">
+                        <Award className="w-5 h-5" />
+                        Reconocimientos
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <ul className="space-y-3">
+                        {docente.reconocimientos.map((rec, index) => (
+                          <li key={index} className="flex items-start gap-2">
+                            <Star className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+                            <span className="text-sm text-amber-900">
+                              {rec}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </CardContent>
+                  </Card>
+                )}
 
               {/* Programas donde enseña */}
               {programasDocente.length > 0 && (
@@ -361,7 +383,10 @@ export function DocenteDetail({ docente }: DocenteDetailProps) {
                           href={`/programas/${programa!.slug}`}
                           className="block p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
                         >
-                          <Badge variant="outline" className="mb-2 text-xs capitalize">
+                          <Badge
+                            variant="outline"
+                            className="mb-2 text-xs capitalize"
+                          >
                             {programa!.tipo}
                           </Badge>
                           <h4 className="text-sm font-medium text-epg-navy group-hover:text-epg-gold transition-colors">
@@ -377,9 +402,12 @@ export function DocenteDetail({ docente }: DocenteDetailProps) {
               {/* CTA - Contactar */}
               <Card className="bg-epg-navy text-white border-0">
                 <CardContent className="pt-6">
-                  <h3 className="font-bold text-lg mb-2">¿Interesado en los programas?</h3>
+                  <h3 className="font-bold text-lg mb-2">
+                    ¿Interesado en los programas?
+                  </h3>
                   <p className="text-gray-300 text-sm mb-4">
-                    Conoce más sobre nuestros programas de postgrado y cómo aplicar.
+                    Conoce más sobre nuestros programas de postgrado y cómo
+                    aplicar.
                   </p>
                   <Button
                     className="w-full bg-epg-gold text-epg-navy hover:bg-epg-gold-dark"
@@ -402,5 +430,5 @@ export function DocenteDetail({ docente }: DocenteDetailProps) {
         </div>
       </section>
     </div>
-  );
+  )
 }

--- a/src/features/estudiantes/components/EstudiantesContent.tsx
+++ b/src/features/estudiantes/components/EstudiantesContent.tsx
@@ -53,6 +53,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { CTABannerSideBySide } from '@/components/ui/cta-banner'
+import { PageHero } from '@/components/ui/page-hero'
 
 // ========================================
 // ICON MAPPER HELPERS
@@ -598,28 +599,13 @@ export function EstudiantesContent() {
   return (
     <div>
       {/* Hero Section */}
-      <section className="bg-epg-navy text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <nav className="text-sm mb-4">
-            <ol className="flex items-center gap-2">
-              <li>
-                <a href="/" className="text-gray-300 hover:text-white">
-                  Inicio
-                </a>
-              </li>
-              <li className="text-gray-400">/</li>
-              <li className="text-epg-gold">Estudiantes</li>
-            </ol>
-          </nav>
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Portal del Estudiante
-          </h1>
-          <p className="text-xl text-gray-300 max-w-3xl">
-            Accede a recursos, trámites y servicios exclusivos para estudiantes
-            de la Escuela de Postgrado.
-          </p>
-        </div>
-      </section>
+      <PageHero
+        breadcrumbs={[{ label: 'Inicio', href: '/' }, { label: 'Estudiantes' }]}
+        title="Portal del Estudiante"
+        subtitle="Accede a recursos, trámites y servicios exclusivos para estudiantes de la Escuela de Postgrado."
+        variant="solid"
+        bgColorClass="bg-epg-navy"
+      />
 
       {/* Accesos Rápidos */}
       <AccesosRapidos />

--- a/src/features/programas/components/ProgramaDetail.tsx
+++ b/src/features/programas/components/ProgramaDetail.tsx
@@ -1,116 +1,118 @@
-import type { Programa } from '@/types';
-import { formatDateSafe } from '@/lib/formatters';
-import { 
-  tipoProgramaLabels, 
-  tipoProgramaColors, 
-  modalidadLabels, 
-  modalidadColors 
-} from '@/lib/constants';
-import { 
-  Calendar, 
-  Clock, 
-  GraduationCap, 
-  MapPin, 
-  User, 
+import type { Programa } from '@/types'
+import { formatDateSafe } from '@/lib/formatters'
+import {
+  tipoProgramaLabels,
+  tipoProgramaColors,
+  modalidadLabels,
+  modalidadColors,
+} from '@/lib/constants'
+import {
+  Calendar,
+  Clock,
+  GraduationCap,
+  MapPin,
+  User,
   BookOpen,
   DollarSign,
   CheckCircle2,
   FileText,
   ArrowLeft,
-  Share2
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
+  Share2,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { PageHero } from '@/components/ui/page-hero'
 
 interface ProgramaDetailProps {
-  programa: Programa;
+  programa: Programa
 }
 
 export function ProgramaDetail({ programa }: ProgramaDetailProps) {
-
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Header */}
-      <div className={`${tipoProgramaColors[programa.tipo]} text-white`}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          {/* Breadcrumb */}
-          <div className="flex items-center gap-2 text-white/80 text-sm mb-6">
-            <a href="/" className="hover:text-white">Inicio</a>
-            <span>/</span>
-            <a href="/programas" className="hover:text-white">Programas</a>
-            <span>/</span>
-            <span className="text-white">{tipoProgramaLabels[programa.tipo]}</span>
-          </div>
-
-          <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
-            <div className="flex-1">
-              <Badge className="bg-white/20 text-white hover:bg-white/30 mb-4">
-                {tipoProgramaLabels[programa.tipo]}
-              </Badge>
-              <h1 className="text-3xl md:text-4xl font-bold mb-4">
-                {programa.nombre}
-              </h1>
-              <p className="text-lg text-white/90 max-w-3xl">
-                {programa.descripcionCorta}
-              </p>
-
-              {/* Quick Info */}
-              <div className="flex flex-wrap gap-4 mt-6">
-                <div className="flex items-center gap-2 bg-white/10 rounded-lg px-4 py-2">
-                  <Clock className="h-5 w-5" />
-                  <span>{programa.duracion}</span>
-                </div>
-                <div className="flex items-center gap-2 bg-white/10 rounded-lg px-4 py-2">
-                  <BookOpen className="h-5 w-5" />
-                  <span>{programa.creditos} créditos</span>
-                </div>
-                <Badge className={modalidadColors[programa.modalidad]}>
-                  {modalidadLabels[programa.modalidad]}
-                </Badge>
+      <PageHero
+        breadcrumbs={[
+          { label: 'Inicio', href: '/' },
+          { label: 'Programas', href: '/programas' },
+          { label: tipoProgramaLabels[programa.tipo] },
+        ]}
+        title={programa.nombre}
+        subtitle={programa.descripcionCorta}
+        badge={{
+          label: tipoProgramaLabels[programa.tipo],
+          className: 'bg-white/20 text-white hover:bg-white/30',
+        }}
+        bgColorClass={tipoProgramaColors[programa.tipo]}
+        variant="solid"
+      >
+        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6 mt-6">
+          <div className="flex-1">
+            {/* Quick Info */}
+            <div className="flex flex-wrap gap-4">
+              <div className="flex items-center gap-2 bg-white/10 rounded-lg px-4 py-2">
+                <Clock className="h-5 w-5" />
+                <span>{programa.duracion}</span>
               </div>
+              <div className="flex items-center gap-2 bg-white/10 rounded-lg px-4 py-2">
+                <BookOpen className="h-5 w-5" />
+                <span>{programa.creditos} créditos</span>
+              </div>
+              <Badge className={modalidadColors[programa.modalidad]}>
+                {modalidadLabels[programa.modalidad]}
+              </Badge>
             </div>
-
-            {/* Action Card */}
-            <Card className="lg:w-80 shadow-xl">
-              <CardHeader className="pb-4">
-                <CardTitle className="text-lg">Inscríbete ahora</CardTitle>
-                <CardDescription>
-                  Proceso de admisión 2025-I
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {programa.fechaInicio && (
-                  <div className="flex items-center gap-3 text-sm">
-                    <Calendar className="h-5 w-5 text-gray-500" />
-                    <div>
-                      <p className="font-medium">Inicio de clases</p>
-                      <p className="text-gray-600">{formatDateSafe(programa.fechaInicio)}</p>
-                    </div>
-                  </div>
-                )}
-                {programa.inversion && (
-                  <div className="flex items-center gap-3 text-sm">
-                    <DollarSign className="h-5 w-5 text-gray-500" />
-                    <div>
-                      <p className="font-medium">Inversión</p>
-                      <p className="text-gray-600">{programa.inversion}</p>
-                    </div>
-                  </div>
-                )}
-                <Separator />
-                <Button className="w-full bg-epg-navy hover:bg-epg-navy-dark" size="lg">
-                  Solicitar información
-                </Button>
-                <Button variant="outline" className="w-full" size="lg">
-                  Descargar brochure
-                </Button>
-              </CardContent>
-            </Card>
           </div>
+
+          {/* Action Card */}
+          <Card className="lg:w-80 shadow-xl">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-lg">Inscríbete ahora</CardTitle>
+              <CardDescription>Proceso de admisión 2025-I</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {programa.fechaInicio && (
+                <div className="flex items-center gap-3 text-sm">
+                  <Calendar className="h-5 w-5 text-gray-500" />
+                  <div>
+                    <p className="font-medium">Inicio de clases</p>
+                    <p className="text-gray-600">
+                      {formatDateSafe(programa.fechaInicio)}
+                    </p>
+                  </div>
+                </div>
+              )}
+              {programa.inversion && (
+                <div className="flex items-center gap-3 text-sm">
+                  <DollarSign className="h-5 w-5 text-gray-500" />
+                  <div>
+                    <p className="font-medium">Inversión</p>
+                    <p className="text-gray-600">{programa.inversion}</p>
+                  </div>
+                </div>
+              )}
+              <Separator />
+              <Button
+                className="w-full bg-epg-navy hover:bg-epg-navy-dark"
+                size="lg"
+              >
+                Solicitar información
+              </Button>
+              <Button variant="outline" className="w-full" size="lg">
+                Descargar brochure
+              </Button>
+            </CardContent>
+          </Card>
         </div>
-      </div>
+      </PageHero>
 
       {/* Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -164,8 +166,9 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
               </CardHeader>
               <CardContent>
                 <p className="text-gray-600 mb-4">
-                  El plan de estudios está diseñado para proporcionar una formación integral 
-                  que combine teoría y práctica, preparándote para los desafíos del mundo profesional.
+                  El plan de estudios está diseñado para proporcionar una
+                  formación integral que combine teoría y práctica, preparándote
+                  para los desafíos del mundo profesional.
                 </p>
                 <Button variant="outline" className="gap-2">
                   <FileText className="h-4 w-4" />
@@ -180,14 +183,18 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
             {/* Info Card */}
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Información del Programa</CardTitle>
+                <CardTitle className="text-lg">
+                  Información del Programa
+                </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="flex items-start gap-3">
                   <GraduationCap className="h-5 w-5 text-epg-navy flex-shrink-0 mt-1" />
                   <div>
                     <p className="text-sm text-gray-500">Tipo de Programa</p>
-                    <p className="font-medium">{tipoProgramaLabels[programa.tipo]}</p>
+                    <p className="font-medium">
+                      {tipoProgramaLabels[programa.tipo]}
+                    </p>
                   </div>
                 </div>
 
@@ -239,7 +246,9 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
             {/* Share Card */}
             <Card>
               <CardContent className="pt-6">
-                <p className="text-sm text-gray-500 mb-3">Compartir este programa</p>
+                <p className="text-sm text-gray-500 mb-3">
+                  Compartir este programa
+                </p>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" className="flex-1">
                     <Share2 className="h-4 w-4 mr-2" />
@@ -250,8 +259,8 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
             </Card>
 
             {/* Back Link */}
-            <a 
-              href="/programas" 
+            <a
+              href="/programas"
               className="flex items-center gap-2 text-epg-navy hover:underline"
             >
               <ArrowLeft className="h-4 w-4" />
@@ -261,5 +270,5 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/publicaciones/components/PublicacionDetail.tsx
+++ b/src/features/publicaciones/components/PublicacionDetail.tsx
@@ -1,8 +1,8 @@
-import type { Publicacion } from '@/types';
-import { formatDate, formatDateTime } from '@/lib/formatters';
-import { tipoPublicacionLabels, tipoPublicacionColors } from '@/lib/constants';
-import { 
-  Calendar, 
+import type { Publicacion } from '@/types'
+import { formatDate, formatDateTime } from '@/lib/formatters'
+import { tipoPublicacionLabels, tipoPublicacionColors } from '@/lib/constants'
+import {
+  Calendar,
   User,
   Tag,
   ArrowLeft,
@@ -12,16 +12,17 @@ import {
   Newspaper,
   CalendarDays,
   Bell,
-  Megaphone
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
+  Megaphone,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { PageHero } from '@/components/ui/page-hero'
 
 interface PublicacionDetailProps {
-  publicacion: Publicacion;
-  publicacionesRelacionadas?: Publicacion[];
+  publicacion: Publicacion
+  publicacionesRelacionadas?: Publicacion[]
 }
 
 const tipoIcons: Record<string, React.ReactNode> = {
@@ -29,67 +30,63 @@ const tipoIcons: Record<string, React.ReactNode> = {
   evento: <CalendarDays className="h-5 w-5" />,
   aviso: <Bell className="h-5 w-5" />,
   comunicado: <Megaphone className="h-5 w-5" />,
-};
+}
 
-export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] }: PublicacionDetailProps) {
-
+export function PublicacionDetail({
+  publicacion,
+  publicacionesRelacionadas = [],
+}: PublicacionDetailProps) {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Header */}
-      <div className={`${tipoPublicacionColors[publicacion.tipo]} text-white`}>
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          {/* Breadcrumb */}
-          <div className="flex items-center gap-2 text-white/80 text-sm mb-6">
-            <a href="/" className="hover:text-white">Inicio</a>
-            <span>/</span>
-            <a href="/publicaciones" className="hover:text-white">Publicaciones</a>
-            <span>/</span>
-            <span className="text-white">{tipoPublicacionLabels[publicacion.tipo]}</span>
+      <PageHero
+        breadcrumbs={[
+          { label: 'Inicio', href: '/' },
+          { label: 'Publicaciones', href: '/publicaciones' },
+          { label: tipoPublicacionLabels[publicacion.tipo] },
+        ]}
+        title={publicacion.titulo}
+        bgColorClass={tipoPublicacionColors[publicacion.tipo]}
+        variant="solid"
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <Badge className="bg-white/20 text-white hover:bg-white/30 gap-1">
+            {tipoIcons[publicacion.tipo]}
+            {tipoPublicacionLabels[publicacion.tipo]}
+          </Badge>
+          {publicacion.destacado && (
+            <Badge className="bg-epg-gold text-epg-navy">Destacado</Badge>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4 text-white/80">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4" />
+            <span>{formatDate(publicacion.fecha)}</span>
           </div>
-
-          <div className="flex items-center gap-3 mb-4">
-            <Badge className="bg-white/20 text-white hover:bg-white/30 gap-1">
-              {tipoIcons[publicacion.tipo]}
-              {tipoPublicacionLabels[publicacion.tipo]}
-            </Badge>
-            {publicacion.destacado && (
-              <Badge className="bg-epg-gold text-epg-navy">
-                Destacado
-              </Badge>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-4xl font-bold mb-4 leading-tight">
-            {publicacion.titulo}
-          </h1>
-
-          <div className="flex flex-wrap items-center gap-4 text-white/80">
+          {publicacion.autor && (
             <div className="flex items-center gap-2">
-              <Calendar className="h-4 w-4" />
-              <span>{formatDate(publicacion.fecha)}</span>
-            </div>
-            {publicacion.autor && (
-              <div className="flex items-center gap-2">
-                <User className="h-4 w-4" />
-                <span>{publicacion.autor}</span>
-              </div>
-            )}
-          </div>
-
-          {/* Fecha del evento (si aplica) */}
-          {publicacion.tipo === 'evento' && publicacion.fechaEvento && (
-            <div className="mt-6 bg-white/10 rounded-lg p-4 inline-block">
-              <div className="flex items-center gap-3">
-                <CalendarDays className="h-6 w-6" />
-                <div>
-                  <p className="text-sm text-white/80">Fecha del evento</p>
-                  <p className="font-semibold">{formatDateTime(publicacion.fechaEvento)}</p>
-                </div>
-              </div>
+              <User className="h-4 w-4" />
+              <span>{publicacion.autor}</span>
             </div>
           )}
         </div>
-      </div>
+
+        {/* Fecha del evento (si aplica) */}
+        {publicacion.tipo === 'evento' && publicacion.fechaEvento && (
+          <div className="mt-6 bg-white/10 rounded-lg p-4 inline-block">
+            <div className="flex items-center gap-3">
+              <CalendarDays className="h-6 w-6" />
+              <div>
+                <p className="text-sm text-white/80">Fecha del evento</p>
+                <p className="font-semibold">
+                  {formatDateTime(publicacion.fechaEvento)}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </PageHero>
 
       {/* Content */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -99,8 +96,8 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
             {/* Image */}
             {publicacion.imagen && (
               <div className="mb-8 rounded-xl overflow-hidden shadow-lg">
-                <img 
-                  src={publicacion.imagen} 
+                <img
+                  src={publicacion.imagen}
                   alt={publicacion.titulo}
                   className="w-full h-64 md:h-96 object-cover"
                 />
@@ -125,7 +122,11 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
                   <div className="flex items-center gap-2 flex-wrap">
                     <Tag className="h-4 w-4 text-gray-500" />
                     {publicacion.etiquetas.map((etiqueta, index) => (
-                      <Badge key={index} variant="secondary" className="text-sm">
+                      <Badge
+                        key={index}
+                        variant="secondary"
+                        className="text-sm"
+                      >
                         {etiqueta}
                       </Badge>
                     ))}
@@ -135,7 +136,9 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
 
               {/* Share */}
               <div className="mt-6 pt-6 border-t flex items-center justify-between">
-                <span className="text-sm text-gray-500">¿Te resultó útil esta información?</span>
+                <span className="text-sm text-gray-500">
+                  ¿Te resultó útil esta información?
+                </span>
                 <Button variant="outline" size="sm" className="gap-2">
                   <Share2 className="h-4 w-4" />
                   Compartir
@@ -144,8 +147,8 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
             </article>
 
             {/* Back Link */}
-            <a 
-              href="/publicaciones" 
+            <a
+              href="/publicaciones"
               className="flex items-center gap-2 text-epg-navy hover:underline mt-8"
             >
               <ArrowLeft className="h-4 w-4" />
@@ -167,7 +170,9 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
                       <Calendar className="h-5 w-5 text-epg-navy flex-shrink-0 mt-1" />
                       <div>
                         <p className="text-sm text-gray-500">Fecha</p>
-                        <p className="font-medium">{formatDateTime(publicacion.fechaEvento)}</p>
+                        <p className="font-medium">
+                          {formatDateTime(publicacion.fechaEvento)}
+                        </p>
                       </div>
                     </div>
                   )}
@@ -190,11 +195,14 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
             {/* Contact Card */}
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">¿Necesitas más información?</CardTitle>
+                <CardTitle className="text-lg">
+                  ¿Necesitas más información?
+                </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <p className="text-sm text-gray-600">
-                  Si tienes preguntas sobre esta publicación, no dudes en contactarnos.
+                  Si tienes preguntas sobre esta publicación, no dudes en
+                  contactarnos.
                 </p>
                 <Button variant="outline" className="w-full">
                   Contactar
@@ -206,17 +214,21 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
             {publicacionesRelacionadas.length > 0 && (
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-lg">Publicaciones Relacionadas</CardTitle>
+                  <CardTitle className="text-lg">
+                    Publicaciones Relacionadas
+                  </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   {publicacionesRelacionadas.slice(0, 3).map((pub) => (
-                    <a 
+                    <a
                       key={pub.id}
                       href={`/publicaciones/${pub.slug}`}
                       className="block group"
                     >
                       <div className="flex gap-3">
-                        <div className={`w-1 ${tipoPublicacionColors[pub.tipo]} rounded-full flex-shrink-0`} />
+                        <div
+                          className={`w-1 ${tipoPublicacionColors[pub.tipo]} rounded-full flex-shrink-0`}
+                        />
                         <div>
                           <p className="font-medium text-sm group-hover:text-epg-navy line-clamp-2">
                             {pub.titulo}
@@ -235,5 +247,5 @@ export function PublicacionDetail({ publicacion, publicacionesRelacionadas = [] 
         </div>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
- Create src/components/ui/page-hero.tsx with breadcrumbs, title, subtitle, badge, children, and variant props
- Support two variants: 'solid' (solid color) and 'gradient' (gradient background)
- Support custom background color classes via bgColorClass prop
- Refactor ProgramaDetail.tsx to use PageHero component with action card in children
- Refactor PublicacionDetail.tsx to use PageHero component with badges and metadata
- Refactor DocenteDetail.tsx to use PageHero component with avatar and contact links
- Refactor EstudiantesContent.tsx to use PageHero component with simple configuration
- Eliminate ~120 lines of duplicated hero/breadcrumb code across four components

Resolves #53 (DUP-006)