### PR TITLE
feat: Extract StatItem component to eliminate duplication

### DIFF
--- a/src/components/ui/stat-item.tsx
+++ b/src/components/ui/stat-item.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react'
+
+interface StatItemProps {
+  value: string | number
+  label: string
+  icon?: ReactNode
+  description?: string
+  variant?: 'card' | 'inline'
+  className?: string
+  valueClassName?: string
+  labelClassName?: string
+  descriptionClassName?: string
+}
+
+export function StatItem({
+  value,
+  label,
+  icon,
+  description,
+  variant = 'inline',
+  className = '',
+  valueClassName = '',
+  labelClassName = '',
+  descriptionClassName = '',
+}: StatItemProps) {
+  if (variant === 'card') {
+    return (
+      <div className={`text-center ${className}`}>
+        {icon && <div className="mb-4">{icon}</div>}
+        <div
+          className={`text-3xl lg:text-4xl font-bold mb-1 ${valueClassName}`}
+        >
+          {value}
+        </div>
+        <div className={`font-medium text-sm mb-1 ${labelClassName}`}>
+          {label}
+        </div>
+        {description && (
+          <div className={`text-xs ${descriptionClassName}`}>{description}</div>
+        )}
+      </div>
+    )
+  }
+
+  // inline variant
+  return (
+    <div className={`text-center ${className}`}>
+      {icon && <div className="mb-2">{icon}</div>}
+      <div className={`text-3xl font-bold ${valueClassName}`}>{value}</div>
+      <div className={`text-sm ${labelClassName}`}>{label}</div>
+      {description && (
+        <div className={`text-xs mt-1 ${descriptionClassName}`}>
+          {description}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/escuela/components/EscuelaContent.tsx
+++ b/src/features/escuela/components/EscuelaContent.tsx
@@ -9,6 +9,7 @@ import {
   tipoDocumentoColors,
   tipoDocumentoLabels,
 } from '@/lib/constants'
+import { StatItem } from '@/components/ui/stat-item'
 import {
   GraduationCap,
   Award,
@@ -120,19 +121,26 @@ function EstadisticasGrid() {
       {estadisticas.map((stat, index) => (
         <div
           key={index}
-          className="bg-white rounded-xl p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+          className="bg-white rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow"
         >
-          <IconCircle
-            icon={stat.icono && iconMap[stat.icono]}
-            size="xl"
-            variant="custom"
-            bgColor="bg-epg-gold/10"
-            iconColor="text-epg-gold"
-            rounded="full"
-            className="mx-auto mb-4"
+          <StatItem
+            value={stat.valor}
+            label={stat.label}
+            variant="card"
+            icon={
+              <IconCircle
+                icon={stat.icono && iconMap[stat.icono]}
+                size="xl"
+                variant="custom"
+                bgColor="bg-epg-gold/10"
+                iconColor="text-epg-gold"
+                rounded="full"
+                className="mx-auto"
+              />
+            }
+            valueClassName="text-epg-navy"
+            labelClassName="text-gray-600"
           />
-          <p className="text-3xl font-bold text-epg-navy mb-1">{stat.valor}</p>
-          <p className="text-sm text-gray-600">{stat.label}</p>
         </div>
       ))}
     </div>

--- a/src/features/home/components/Hero.tsx
+++ b/src/features/home/components/Hero.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { ArrowRight, CheckCircle } from 'lucide-react';
+import React from 'react'
+import { ArrowRight, CheckCircle } from 'lucide-react'
+import { StatItem } from '@/components/ui/stat-item'
 
 export const Hero: React.FC = () => {
   return (
     <section className="relative w-full min-h-[600px] lg:min-h-[700px] flex items-center overflow-hidden">
       {/* Background Image */}
       <div className="absolute inset-0">
-        <img 
+        <img
           src="/images/hero/epg-fondo.jpeg"
           alt="Escuela de Postgrado UNAP"
           className="w-full h-full object-cover object-center"
@@ -49,19 +50,21 @@ export const Hero: React.FC = () => {
 
             {/* Subtext */}
             <p className="text-lg sm:text-xl text-gray-300 mb-8 max-w-lg leading-relaxed">
-              Forma parte de la Escuela de Postgrado líder en la Amazonía. Maestrías, Doctorados y Diplomados diseñados para transformar tu futuro profesional.
+              Forma parte de la Escuela de Postgrado líder en la Amazonía.
+              Maestrías, Doctorados y Diplomados diseñados para transformar tu
+              futuro profesional.
             </p>
 
             {/* CTA Buttons */}
             <div className="flex flex-wrap gap-4 mb-12">
-              <a 
+              <a
                 href="/admision"
                 className="inline-flex items-center gap-2 bg-epg-gold hover:bg-epg-gold-dark text-epg-navy px-6 py-3 rounded-lg text-base font-bold transition-all hover:shadow-lg hover:shadow-epg-gold/20"
               >
                 Postula ahora
                 <ArrowRight className="w-5 h-5" />
               </a>
-              <a 
+              <a
                 href="/programas"
                 className="inline-flex items-center gap-2 border-2 border-white/30 hover:border-white text-white px-6 py-3 rounded-lg text-base font-medium transition-all hover:bg-white/10"
               >
@@ -71,18 +74,27 @@ export const Hero: React.FC = () => {
 
             {/* Quick Stats */}
             <div className="flex flex-wrap gap-8">
-              <div className="text-center">
-                <div className="text-3xl font-bold text-epg-gold">35+</div>
-                <div className="text-sm text-gray-400">Años de experiencia</div>
-              </div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-epg-gold">2,500+</div>
-                <div className="text-sm text-gray-400">Egresados</div>
-              </div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-epg-gold">20+</div>
-                <div className="text-sm text-gray-400">Programas</div>
-              </div>
+              <StatItem
+                value="35+"
+                label="Años de experiencia"
+                variant="inline"
+                valueClassName="text-epg-gold"
+                labelClassName="text-gray-400"
+              />
+              <StatItem
+                value="2,500+"
+                label="Egresados"
+                variant="inline"
+                valueClassName="text-epg-gold"
+                labelClassName="text-gray-400"
+              />
+              <StatItem
+                value="20+"
+                label="Programas"
+                variant="inline"
+                valueClassName="text-epg-gold"
+                labelClassName="text-gray-400"
+              />
             </div>
           </div>
 
@@ -90,18 +102,21 @@ export const Hero: React.FC = () => {
           <div className="hidden lg:block">
             <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20">
               <div className="flex items-center gap-2 mb-4">
-<span className="inline-block bg-success text-success-foreground text-xs font-bold px-3 py-1 rounded-full animate-pulse">
+                <span className="inline-block bg-success text-success-foreground text-xs font-bold px-3 py-1 rounded-full animate-pulse">
                   ABIERTO
                 </span>
-                <span className="text-white/80 text-sm">Proceso de Admisión 2025-I</span>
+                <span className="text-white/80 text-sm">
+                  Proceso de Admisión 2025-I
+                </span>
               </div>
-              
+
               <h3 className="text-2xl font-bold text-white mb-4">
                 ¡Inscripciones abiertas!
               </h3>
-              
+
               <p className="text-gray-300 mb-6">
-                Aprovecha esta oportunidad para avanzar en tu carrera profesional. Contamos con vacantes limitadas.
+                Aprovecha esta oportunidad para avanzar en tu carrera
+                profesional. Contamos con vacantes limitadas.
               </p>
 
               <div className="space-y-3 mb-6">
@@ -136,5 +151,5 @@ export const Hero: React.FC = () => {
         </div>
       </div>
     </section>
-  );
-};
+  )
+}

--- a/src/features/home/components/StatsSection.tsx
+++ b/src/features/home/components/StatsSection.tsx
@@ -8,6 +8,7 @@ import {
   ThumbsUp,
 } from 'lucide-react'
 import { SectionHeader } from '@/components/ui/section-header'
+import { StatItem } from '@/components/ui/stat-item'
 import { IconCircle } from '@/components/ui/icon-circle'
 
 const stats = [
@@ -76,26 +77,28 @@ export const StatsSection: React.FC = () => {
             return (
               <div
                 key={index}
-                className="text-center p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 transition-all group"
+                className="p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 transition-all group"
               >
-                <IconCircle
-                  icon={<Icon className="w-6 h-6" />}
-                  size="md"
-                  variant="custom"
-                  bgColor="bg-epg-gold/20"
-                  iconColor="text-epg-gold"
-                  rounded="xl"
-                  className="mx-auto mb-4 group-hover:bg-epg-gold/30 transition-colors"
+                <StatItem
+                  value={stat.value}
+                  label={stat.label}
+                  description={stat.description}
+                  variant="card"
+                  icon={
+                    <IconCircle
+                      icon={<Icon className="w-6 h-6" />}
+                      size="md"
+                      variant="custom"
+                      bgColor="bg-epg-gold/20"
+                      iconColor="text-epg-gold"
+                      rounded="xl"
+                      className="mx-auto group-hover:bg-epg-gold/30 transition-colors"
+                    />
+                  }
+                  valueClassName="text-white"
+                  labelClassName="text-epg-gold"
+                  descriptionClassName="text-gray-500 hidden lg:block"
                 />
-                <div className="text-3xl lg:text-4xl font-bold text-white mb-1">
-                  {stat.value}
-                </div>
-                <div className="text-epg-gold font-medium text-sm mb-1">
-                  {stat.label}
-                </div>
-                <div className="text-gray-500 text-xs hidden lg:block">
-                  {stat.description}
-                </div>
               </div>
             )
           })}


### PR DESCRIPTION
- Create src/components/ui/stat-item.tsx with value, label, icon, description props
- Support two variants: 'card' (with larger text) and 'inline' (compact)
- Refactor StatsSection.tsx to use StatItem with IconCircle integration
- Refactor Hero.tsx to use StatItem for quick stats display
- Refactor EscuelaContent.tsx to use StatItem in statistics grid
- Standardize stat presentation across all sections
- Eliminate ~50 lines of duplicated stat item code

Resolves #58 (DUP-011)