### PR TITLE
feat: Extract DocumentDownloadItem component to eliminate duplication

### DIFF
--- a/src/components/ui/document-download-item.tsx
+++ b/src/components/ui/document-download-item.tsx
@@ -1,0 +1,78 @@
+import { FileText, Download } from 'lucide-react'
+import { Badge } from './badge'
+
+interface DocumentDownloadItemProps {
+  name: string
+  url: string
+  type?: 'pdf' | 'docx' | 'xlsx'
+  date?: string
+  variant?: 'simple' | 'detailed'
+  className?: string
+}
+
+const typeStyles = {
+  pdf: { bg: 'bg-red-100', text: 'text-red-600' },
+  docx: { bg: 'bg-blue-100', text: 'text-blue-600' },
+  xlsx: { bg: 'bg-green-100', text: 'text-green-600' },
+}
+
+export function DocumentDownloadItem({
+  name,
+  url,
+  type,
+  date,
+  variant = 'simple',
+  className = '',
+}: DocumentDownloadItemProps) {
+  if (variant === 'simple') {
+    return (
+      <a
+        href={url}
+        className={`flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group ${className}`}
+      >
+        <div className="flex-1 min-w-0">
+          <p className="font-medium text-sm text-gray-900 group-hover:text-epg-navy truncate">
+            {name}
+          </p>
+        </div>
+        <Download className="h-4 w-4 text-gray-400 group-hover:text-epg-gold flex-shrink-0 ml-2" />
+      </a>
+    )
+  }
+
+  // detailed variant
+  const style = type
+    ? typeStyles[type]
+    : { bg: 'bg-gray-100', text: 'text-gray-600' }
+
+  return (
+    <a
+      href={url}
+      className={`flex items-center gap-4 bg-white rounded-lg p-4 hover:shadow-md transition-shadow group ${className}`}
+    >
+      <div
+        className={`w-10 h-10 ${style.bg} rounded flex items-center justify-center flex-shrink-0`}
+      >
+        <FileText className={`w-5 h-5 ${style.text}`} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <h4 className="font-medium text-epg-navy group-hover:text-epg-gold transition-colors truncate">
+          {name}
+        </h4>
+        <div className="flex items-center gap-2">
+          {type && (
+            <Badge variant="outline" className="text-xs uppercase">
+              {type}
+            </Badge>
+          )}
+          {date && (
+            <span className="text-xs text-gray-500">
+              Actualizado: {new Date(date).toLocaleDateString('es-PE')}
+            </span>
+          )}
+        </div>
+      </div>
+      <Download className="w-5 h-5 text-gray-400 group-hover:text-epg-gold flex-shrink-0" />
+    </a>
+  )
+}

--- a/src/features/escuela/components/EscuelaContent.tsx
+++ b/src/features/escuela/components/EscuelaContent.tsx
@@ -10,6 +10,7 @@ import {
   tipoDocumentoLabels,
 } from '@/lib/constants'
 import { StatItem } from '@/components/ui/stat-item'
+import { DocumentDownloadItem } from '@/components/ui/document-download-item'
 import {
   GraduationCap,
   Award,
@@ -209,18 +210,12 @@ function Documentos() {
         </CardHeader>
         <CardContent className="space-y-3">
           {reglamentos.map((doc) => (
-            <a
+            <DocumentDownloadItem
               key={doc.id}
-              href={doc.url}
-              className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-sm text-gray-900 group-hover:text-epg-navy truncate">
-                  {doc.nombre}
-                </p>
-              </div>
-              <Download className="h-4 w-4 text-gray-400 group-hover:text-epg-gold flex-shrink-0 ml-2" />
-            </a>
+              name={doc.nombre}
+              url={doc.url}
+              variant="simple"
+            />
           ))}
         </CardContent>
       </Card>
@@ -236,18 +231,12 @@ function Documentos() {
         </CardHeader>
         <CardContent className="space-y-3">
           {formatos.map((doc) => (
-            <a
+            <DocumentDownloadItem
               key={doc.id}
-              href={doc.url}
-              className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-sm text-gray-900 group-hover:text-epg-navy truncate">
-                  {doc.nombre}
-                </p>
-              </div>
-              <Download className="h-4 w-4 text-gray-400 group-hover:text-epg-gold flex-shrink-0 ml-2" />
-            </a>
+              name={doc.nombre}
+              url={doc.url}
+              variant="simple"
+            />
           ))}
         </CardContent>
       </Card>
@@ -263,18 +252,12 @@ function Documentos() {
         </CardHeader>
         <CardContent className="space-y-3">
           {guias.map((doc) => (
-            <a
+            <DocumentDownloadItem
               key={doc.id}
-              href={doc.url}
-              className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-sm text-gray-900 group-hover:text-epg-navy truncate">
-                  {doc.nombre}
-                </p>
-              </div>
-              <Download className="h-4 w-4 text-gray-400 group-hover:text-epg-gold flex-shrink-0 ml-2" />
-            </a>
+              name={doc.nombre}
+              url={doc.url}
+              variant="simple"
+            />
           ))}
         </CardContent>
       </Card>

--- a/src/features/estudiantes/components/EstudiantesContent.tsx
+++ b/src/features/estudiantes/components/EstudiantesContent.tsx
@@ -43,6 +43,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { SectionHeader } from '@/components/ui/section-header'
 import { Accordion, type AccordionItem } from '@/components/ui/accordion'
+import { DocumentDownloadItem } from '@/components/ui/document-download-item'
 import {
   Card,
   CardContent,
@@ -315,39 +316,16 @@ function DocumentosDescargables() {
         />
 
         <div className="grid md:grid-cols-2 gap-4">
-          {documentosDescargables.map((doc) => {
-            const style = tipoIcon[doc.tipo]
-            return (
-              <a
-                key={doc.id}
-                href={doc.url}
-                className="flex items-center gap-4 bg-white rounded-lg p-4 hover:shadow-md transition-shadow group"
-              >
-                <div
-                  className={`w-10 h-10 ${style.bg} rounded flex items-center justify-center flex-shrink-0`}
-                >
-                  <FileText className={`w-5 h-5 ${style.text}`} />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h4 className="font-medium text-epg-navy group-hover:text-epg-gold transition-colors truncate">
-                    {doc.nombre}
-                  </h4>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="text-xs uppercase">
-                      {doc.tipo}
-                    </Badge>
-                    <span className="text-xs text-gray-500">
-                      Actualizado:{' '}
-                      {new Date(doc.fechaActualizacion).toLocaleDateString(
-                        'es-PE',
-                      )}
-                    </span>
-                  </div>
-                </div>
-                <Download className="w-5 h-5 text-gray-400 group-hover:text-epg-gold flex-shrink-0" />
-              </a>
-            )
-          })}
+          {documentosDescargables.map((doc) => (
+            <DocumentDownloadItem
+              key={doc.id}
+              name={doc.nombre}
+              url={doc.url}
+              type={doc.tipo}
+              date={doc.fechaActualizacion}
+              variant="detailed"
+            />
+          ))}
         </div>
 
         <div className="text-center mt-8">


### PR DESCRIPTION
- Create src/components/ui/document-download-item.tsx with name, url, type, date props
- Support two variants: 'simple' (minimal) and 'detailed' (with icon and metadata)
- Centralize file type icon management (pdf/docx/xlsx with color coding)
- Refactor EscuelaContent.tsx to use DocumentDownloadItem for all document categories
- Refactor EstudiantesContent.tsx to use DocumentDownloadItem with detailed variant
- Standardize document download UI across the application
- Eliminate ~50 lines of duplicated document item code

Resolves #59 (DUP-012)