### PR TITLE
feat(home): Usar campo destacado en lugar de IDs hardcodeados (HOME-006)

### DIFF
--- a/src/data/programas.ts
+++ b/src/data/programas.ts
@@ -23,6 +23,7 @@ export const programas: Programa[] = [
     coordinador: 'Dr. Carlos Mendoza Ríos',
     inversion: 'S/. 12,500.00 (total)',
     imagen: '/images/programas/gestion-publica.jpg',
+    destacado: true,
   },
   {
     id: 'mae-002',
@@ -45,6 +46,7 @@ export const programas: Programa[] = [
     coordinador: 'Dra. Patricia Vargas Lozano',
     inversion: 'S/. 14,000.00 (total)',
     imagen: '/images/programas/derecho.jpg',
+    destacado: true,
   },
   {
     id: 'mae-003',
@@ -66,6 +68,7 @@ export const programas: Programa[] = [
     coordinador: 'Dr. Roberto Sánchez Torres',
     inversion: 'S/. 11,000.00 (total)',
     imagen: '/images/programas/educacion.jpg',
+    destacado: true,
   },
   {
     id: 'mae-004',
@@ -132,6 +135,7 @@ export const programas: Programa[] = [
     coordinador: 'Dr. Fernando Castillo Mendoza',
     inversion: 'S/. 25,000.00 (total)',
     imagen: '/images/programas/derecho.jpg',
+    destacado: true,
   },
   {
     id: 'doc-002',

--- a/src/features/home/components/FeaturedPrograms.tsx
+++ b/src/features/home/components/FeaturedPrograms.tsx
@@ -7,9 +7,20 @@ import { LinkArrow } from '@/components/ui/link-arrow'
 import { ResourceCard } from '@/components/ui/resource-card'
 
 // Get featured programs from data
-const featuredPrograms = programas.filter((p) =>
-  ['mae-001', 'mae-002', 'doc-001', 'mae-003'].includes(p.id),
-)
+const featuredPrograms = programas
+  .filter((p) => p.destacado)
+  .slice(0, 4)
+
+// Fallback: if less than 4 featured, fill with active programs
+const displayPrograms =
+  featuredPrograms.length >= 4
+    ? featuredPrograms
+    : [
+        ...featuredPrograms,
+        ...programas
+          .filter((p) => !p.destacado && p.estado === 'activo')
+          .slice(0, 4 - featuredPrograms.length),
+      ]
 
 export const FeaturedPrograms: React.FC = () => {
   return (
@@ -36,7 +47,7 @@ export const FeaturedPrograms: React.FC = () => {
 
         {/* Programs Grid */}
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {featuredPrograms.map((program) => {
+          {displayPrograms.map((program) => {
             const typeConfig = getProgramTypeConfig(program.tipo)
             const Icon = typeConfig.icon || GraduationCap
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Programa {
   planEstudios?: string; // URL al PDF
   coordinador?: string;
   inversion?: string;
+  destacado?: boolean; // Mostrar en sección de programas destacados del Home
 }
 
 // --- BÚSQUEDAS POPULARES ---


### PR DESCRIPTION
## 🎯 Resumen

Elimina el array hardcodeado de IDs de programas destacados y usa un campo `destacado` en los datos, haciendo el sistema más flexible, mantenible y robusto.

## 📝 Cambios realizados

### Nueva propiedad en Programa
- ✅ Agregado campo `destacado?: boolean` a interfaz `Programa`
- ✅ Campo opcional: no rompe programas existentes
- ✅ Documentado con comentario descriptivo

### Programas marcados como destacados
- ✅ `mae-001`: Maestría en Gestión Pública
- ✅ `mae-002`: Maestría en Derecho Civil y Comercial  
- ✅ `mae-003`: Maestría en Educación con mención en Docencia Universitaria
- ✅ `doc-001`: Doctorado en Derecho

### Componente actualizado
- ✅ Eliminado array hardcodeado: `['mae-001', 'mae-002', 'doc-001', 'mae-003']`
- ✅ Filtrado dinámico: `programas.filter(p => p.destacado)`
- ✅ Límite de 4 programas: `.slice(0, 4)`
- ✅ Fallback robusto implementado

### Sistema de fallback
```typescript
const featuredPrograms = programas.filter((p) => p.destacado).slice(0, 4)

const displayPrograms =
  featuredPrograms.length >= 4
    ? featuredPrograms
    : [
        ...featuredPrograms,
        ...programas
          .filter((p) => !p.destacado && p.estado === 'activo')
          .slice(0, 4 - featuredPrograms.length),
      ]
```

**Lógica:**
- Si hay 4+ destacados → Mostrar primeros 4 destacados
- Si hay menos de 4 destacados → Completar con programas activos

## 🐛 Issue relacionado

Closes #98

## 📂 Archivos modificados

- `src/types/index.ts` (+1 línea)
- `src/data/programas.ts` (+4 líneas)
- `src/features/home/components/FeaturedPrograms.tsx` (+15, -4 líneas)

**Total:** 3 archivos, 20 inserciones, 4 eliminaciones

## ✅ Testing Checklist

- [ ] Los 4 programas destacados se muestran correctamente en el Home
- [ ] Los programas son los esperados (Gestión Pública, Derecho Civil, Educación, Doctorado Derecho)
- [ ] El orden de aparición es correcto
- [ ] Si se quita `destacado: true` de un programa, deja de mostrarse
- [ ] Si se agrega `destacado: true` a otro programa, aparece
- [ ] Fallback funciona: si solo hay 2 destacados, completa con 2 activos
- [ ] No hay errores de TypeScript
- [ ] Grid responsive sigue funcionando (4 columnas en desktop, 2 en tablet, 1 en móvil)

## 🎨 Comparación antes/después

### Antes (hardcodeado):
```tsx
const featuredPrograms = programas.filter((p) =>
  ['mae-001', 'mae-002', 'doc-001', 'mae-003'].includes(p.id),
)
```

**Problemas:**
- ❌ Si cambian IDs, el Home se rompe
- ❌ Difícil de mantener
- ❌ Administradores no pueden cambiar destacados fácilmente

### Después (basado en datos):
```tsx
const featuredPrograms = programas.filter((p) => p.destacado).slice(0, 4)
```

**Ventajas:**
- ✅ Resiliente: no depende de IDs específicos
- ✅ Fácil de mantener
- ✅ Administradores pueden cambiar destacados editando `programas.ts`
- ✅ Fallback automático si faltan destacados

## 📊 Ventajas de esta implementación

### Mantenibilidad
- ✅ Cambiar destacados: solo editar `destacado: true` en datos
- ✅ No tocar código del componente
- ✅ Única fuente de verdad en los datos

### Robustez
- ✅ No se rompe si cambian IDs de programas
- ✅ Fallback previene UI vacío
- ✅ Siempre muestra 4 programas (o los disponibles)

### Escalabilidad
- ✅ Preparado para CMS futuro
- ✅ Fácil agregar más campos: `destacadoOrden?: number`
- ✅ Filtros adicionales simples de implementar

## 🔮 Futuras mejoras posibles

### Ordenamiento personalizado
```typescript
destacado?: boolean;
destacadoOrden?: number; // 1, 2, 3, 4...
```

### Fechas de destacado
```typescript
destacado?: boolean;
destacadoDesde?: string;
destacadoHasta?: string;
```

### Múltiples categorías
```typescript
destacadoEn?: ('home' | 'programas' | 'admision')[];
```

## 📌 Datos actuales

Programas actualmente destacados:

1. **Maestría en Gestión Pública** (`mae-001`)
   - Tipo: Maestría
   - Modalidad: Semipresencial
   - Inversión: S/. 12,500

2. **Maestría en Derecho Civil y Comercial** (`mae-002`)
   - Tipo: Maestría  
   - Modalidad: Presencial
   - Inversión: S/. 14,000

3. **Maestría en Educación** (`mae-003`)
   - Tipo: Maestría
   - Modalidad: Semipresencial
   - Inversión: S/. 11,000

4. **Doctorado en Derecho** (`doc-001`)
   - Tipo: Doctorado
   - Modalidad: Presencial
   - Inversión: S/. 25,000

## 🔗 Uso futuro

Para destacar un programa diferente:

```typescript
// En src/data/programas.ts
{
  id: 'mae-005',
  nombre: 'Nueva Maestría',
  // ... otros campos
  destacado: true, // ← Agregar esta línea
}
```

¡Y listo! Aparecerá automáticamente en el Home.