### PR TITLE
feat(home): Mejorar responsividad del grid de programas (HOME-007)

### DIFF
--- a/src/features/home/components/FeaturedPrograms.tsx
+++ b/src/features/home/components/FeaturedPrograms.tsx
@@ -46,7 +46,7 @@ export const FeaturedPrograms: React.FC = () => {
         />
 
         {/* Programs Grid */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6">
           {displayPrograms.map((program) => {
             const typeConfig = getProgramTypeConfig(program.tipo)
             const Icon = typeConfig.icon || GraduationCap


### PR DESCRIPTION
## 🎯 Resumen

Mejora la responsividad del grid de programas destacados, evitando columnas muy estrechas en pantallas medianas (1024-1280px).

## 📝 Cambios realizados

### Breakpoints mejorados
- ✅ **Antes:** `md:grid-cols-2 lg:grid-cols-4` (salto brusco de 2 a 4 columnas)
- ✅ **Después:** `sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4` (progresión suave)

### Gaps responsive
- ✅ **Antes:** `gap-6` (fijo)
- ✅ **Después:** `gap-4 md:gap-6` (más compacto en móvil)

### Distribución resultante
- 📱 **Móvil (<640px):** 1 columna (100% ancho)
- 📱 **Tablet (640-1024px):** 2 columnas (~50% c/u)
- 💻 **Desktop (1024-1280px):** 3 columnas (~33% c/u) ← MEJORA PRINCIPAL
- 🖥️ **Large (1280px+):** 4 columnas (25% c/u)

## 🐛 Issue relacionado

Closes #99

## 📂 Archivos modificados

- `src/features/home/components/FeaturedPrograms.tsx` (1 línea)

## ✅ Testing Checklist

- [ ] Móvil (375px): 1 columna, tarjetas full-width
- [ ] Tablet (768px): 2 columnas, tarjetas bien proporcionadas
- [ ] Desktop (1024px): 3 columnas, NO muy estrechas ✓
- [ ] Large (1440px): 4 columnas, espaciado óptimo
- [ ] Gaps se ajustan correctamente entre breakpoints