### PR TITLE
feat(home): Implementar contadores dinámicos para categorías de programas (HOME-008)

### DIFF
--- a/src/features/home/components/FeaturedPrograms.tsx
+++ b/src/features/home/components/FeaturedPrograms.tsx
@@ -22,7 +22,18 @@ const displayPrograms =
           .slice(0, 4 - featuredPrograms.length),
       ]
 
+// Helper function for pluralization
+const pluralize = (count: number, singular: string, plural: string): string => {
+  return count === 1 ? `${count} ${singular}` : `${count} ${plural}`
+}
+
 export const FeaturedPrograms: React.FC = () => {
+  // Calculate dynamic counters for each program type
+  const maestriasCount = programas.filter((p) => p.tipo === 'maestria' && p.estado === 'activo').length
+  const doctoradosCount = programas.filter((p) => p.tipo === 'doctorado' && p.estado === 'activo').length
+  const formacionContinuaCount = programas.filter(
+    (p) => (p.tipo === 'diplomado' || p.tipo === 'curso') && p.estado === 'activo'
+  ).length
   return (
     <section className="section-py px-4 sm:px-6 lg:px-8 bg-gray-50">
       <div className="container-main">
@@ -153,7 +164,7 @@ export const FeaturedPrograms: React.FC = () => {
             href="/programas/maestrias"
             icon={GraduationCap}
             title="Maestrías"
-            description="Programas de 2 años para profesionales que buscan especialización."
+            description={`${pluralize(maestriasCount, 'programa disponible', 'programas disponibles')} de 2 años para profesionales que buscan especialización.`}
             variant="gradient-navy"
           />
 
@@ -161,7 +172,7 @@ export const FeaturedPrograms: React.FC = () => {
             href="/programas/doctorados"
             icon={Award}
             title="Doctorados"
-            description="Investigación de alto nivel para líderes académicos."
+            description={`${pluralize(doctoradosCount, 'programa disponible', 'programas disponibles')} de investigación de alto nivel para líderes académicos.`}
             variant="gradient-gold"
           />
 
@@ -175,7 +186,7 @@ export const FeaturedPrograms: React.FC = () => {
               Diplomados y cursos cortos de actualización profesional.
             </p>
             <span className="inline-flex items-center gap-1 text-epg-gold font-medium text-sm group-hover:gap-2 transition-all">
-              5 programas disponibles
+              {pluralize(formacionContinuaCount, 'programa disponible', 'programas disponibles')}
               <ArrowRight className="w-4 h-4" />
             </span>
           </a>


### PR DESCRIPTION
## 🎯 Resumen

Reemplaza los contadores hardcodeados en las cards de categorías de programas (Maestrías, Doctorados, Formación Continua) con contadores dinámicos que se calculan automáticamente desde los datos.

## 📝 Cambios realizados

### Función helper de pluralización
- ✅ Agregada función `pluralize(count, singular, plural)` para manejo correcto de textos
- ✅ Retorna forma singular cuando count = 1, plural en caso contrario
- ✅ Formato: "1 programa disponible" / "5 programas disponibles"

### Contadores dinámicos
- ✅ **Maestrías:** Cuenta programas donde `tipo === 'maestria' && estado === 'activo'`
- ✅ **Doctorados:** Cuenta programas donde `tipo === 'doctorado' && estado === 'activo'`
- ✅ **Formación Continua:** Cuenta programas donde `(tipo === 'diplomado' || tipo === 'curso') && estado === 'activo'`

### Cards actualizadas
1. **Maestrías (ResourceCard):**
   - Antes: "Programas de 2 años para profesionales que buscan especialización."
   - Después: "X programa(s) disponible(s) de 2 años para profesionales que buscan especialización."

2. **Doctorados (ResourceCard):**
   - Antes: "Investigación de alto nivel para líderes académicos."
   - Después: "X programa(s) disponible(s) de investigación de alto nivel para líderes académicos."

3. **Formación Continua (Custom card):**
   - Antes: "5 programas disponibles" (hardcodeado)
   - Después: "X programa(s) disponible(s)" (dinámico)

## 🐛 Issue relacionado

Closes #100

## 📂 Archivos modificados

- `src/features/home/components/FeaturedPrograms.tsx` (+14, -3)

## ✅ Beneficios

- ✅ Los contadores se actualizan automáticamente al agregar/eliminar programas
- ✅ No más desincronización entre datos y UI
- ✅ Pluralización correcta en español
- ✅ Solo cuenta programas activos

## 🧪 Testing Checklist

- [ ] Verificar que los contadores reflejan la cantidad real de programas activos
- [ ] Probar pluralización: agregar/quitar programas hasta llegar a 1
- [ ] Confirmar que solo cuenta programas con `estado === 'activo'`
- [ ] Verificar visualmente las 3 cards (Maestrías, Doctorados, Formación Continua)