### PR TITLE
HOME-018: Validar estado de convocatoria (badges dinámicos)

### DIFF
--- a/src/features/home/components/AdmissionCTA.tsx
+++ b/src/features/home/components/AdmissionCTA.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ArrowRight, Calendar, FileText, Phone } from 'lucide-react'
+import { getConvocatoriasAbiertas } from '@/data/convocatorias'
 
 export const AdmissionCTA: React.FC = () => {
   return (
@@ -14,20 +15,33 @@ export const AdmissionCTA: React.FC = () => {
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           {/* Left Content */}
           <div>
-            <div className="inline-flex items-center gap-2 bg-epg-navy text-white px-4 py-2 rounded-full text-sm font-medium mb-6">
-              <span className="w-2 h-2 bg-success rounded-full animate-pulse" aria-hidden="true" />
-              Convocatoria abierta
-            </div>
+            {(() => {
+              const abiertas = getConvocatoriasAbiertas()
+              const abierta = abiertas.length > 0
+              const nombre = abiertas[0]?.nombre
+              return (
+                <div className="mb-6">
+                  <div className="inline-flex items-center gap-2 bg-epg-navy text-white px-4 py-2 rounded-full text-sm font-medium">
+                    <span
+                      className={`w-2 h-2 rounded-full ${abierta ? 'bg-success animate-pulse' : 'bg-amber-500'}`}
+                      aria-hidden="true"
+                    />
+                    {abierta ? 'Convocatoria abierta' : 'Sin convocatoria abierta'}
+                  </div>
+                  <p className="text-epg-navy/80 text-sm mt-2">
+                    {abierta
+                      ? `${nombre ?? 'Proceso de admisión'} está abierto. No pierdas la oportunidad de postular.`
+                      : 'Actualmente no hay procesos de admisión abiertos. Revisa nuestras próximas convocatorias.'}
+                  </p>
+                </div>
+              )
+            })()}
 
             <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-epg-navy mb-6 leading-tight">
               Inicia tu camino hacia la excelencia académica
             </h2>
 
-            <p className="text-epg-navy/80 text-lg mb-8 max-w-lg">
-              El proceso de admisión 2025-I está abierto. No pierdas la
-              oportunidad de formar parte de la Escuela de Postgrado líder en la
-              Amazonía.
-            </p>
+            {/* paragraph moved above and now dynamic */}
 
             <div className="flex flex-wrap gap-4">
               <a

--- a/src/features/home/components/Hero.tsx
+++ b/src/features/home/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight } from 'lucide-react';
 import React from 'react';
+import { getConvocatoriasAbiertas } from '@/data/convocatorias';
 
 export const Hero: React.FC = () => {
   return (
@@ -24,6 +25,23 @@ export const Hero: React.FC = () => {
       {/* Content */}
       <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12 lg:px-16 py-12">
         <div className="max-w-3xl ml-0">
+          {/* Status badge (dynamic) */}
+          {(() => {
+            const abiertas = getConvocatoriasAbiertas();
+            const abierta = abiertas.length > 0;
+            return (
+              <div className="mb-4">
+                <div className="inline-flex items-center gap-2 bg-epg-navy text-white px-3 py-1 rounded-full text-sm font-medium">
+                  <span
+                    className={`w-2 h-2 rounded-full ${abierta ? 'bg-success animate-pulse' : 'bg-amber-500'}`}
+                    aria-hidden="true"
+                  />
+                  {abierta ? 'Convocatoria abierta' : 'Sin convocatoria abierta'}
+                </div>
+              </div>
+            );
+          })()}
+
           {/* Main Heading */}
           <h1 className="font-sans font-extrabold tracking-tight leading-tight mb-4">
             <span className="block text-white text-4xl sm:text-5xl lg:text-6xl uppercase">


### PR DESCRIPTION
## Summary\n- Use data from  to render dynamic admission status badges on Hero and AdmissionCTA.\n- Show green pulsing badge when there is an open convocatoria, amber badge otherwise.\n\n## Changes\n- src/features/home/components/Hero.tsx: added dynamic badge using \n- src/features/home/components/AdmissionCTA.tsx: replaced hardcoded badge/text with dynamic content from convocatorias data\n\n## Notes\n- AdmissionCTA description text was made dynamic; let me know if you prefer a different wording or to pull more details from the convocatoria object.\n