### PR TITLE
feat: add scroll animations to all home page sections (issue #149)

### DIFF
--- a/src/components/ui/scroll-animation.tsx
+++ b/src/components/ui/scroll-animation.tsx
@@ -1,0 +1,73 @@
+import React, { ReactNode } from 'react'
+import { useScrollAnimation } from '@/hooks/useScrollAnimation'
+
+interface ScrollAnimationProps {
+  children: ReactNode
+  animation?: 'fade-in' | 'fade-in-up' | 'fade-in-down' | 'fade-in-left' | 'fade-in-right' | 'zoom-in' | 'slide-up'
+  delay?: number
+  duration?: number
+  className?: string
+  threshold?: number
+}
+
+export function ScrollAnimation({
+  children,
+  animation = 'fade-in-up',
+  delay = 0,
+  duration = 600,
+  className = '',
+  threshold = 0.1,
+}: ScrollAnimationProps) {
+  const { ref, isVisible } = useScrollAnimation({ threshold })
+
+  const animationClasses: Record<string, string> = {
+    'fade-in': 'animate-fade-in',
+    'fade-in-up': 'animate-fade-in-up',
+    'fade-in-down': 'animate-fade-in-down',
+    'fade-in-left': 'animate-fade-in-left',
+    'fade-in-right': 'animate-fade-in-right',
+    'zoom-in': 'animate-zoom-in',
+    'slide-up': 'animate-slide-up',
+  }
+
+  return (
+    <div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      className={`${className} ${isVisible ? animationClasses[animation] : 'opacity-0'}`}
+      style={{
+        animationDelay: `${delay}ms`,
+        animationDuration: `${duration}ms`,
+        animationFillMode: 'forwards',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface StaggerContainerProps {
+  children: ReactNode
+  staggerDelay?: number
+  className?: string
+}
+
+export function StaggerContainer({ children, staggerDelay = 100, className = '' }: StaggerContainerProps) {
+  const { ref, isVisible } = useScrollAnimation()
+
+  return (
+    <div ref={ref as React.RefObject<HTMLDivElement>} className={className}>
+      {React.Children.map(children, (child, index) => (
+        <div
+          className={isVisible ? 'animate-fade-in-up' : 'opacity-0'}
+          style={{
+            animationDelay: `${index * staggerDelay}ms`,
+            animationDuration: '500ms',
+            animationFillMode: 'forwards',
+          }}
+        >
+          {child}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/features/home/components/AdmissionCTA.tsx
+++ b/src/features/home/components/AdmissionCTA.tsx
@@ -8,15 +8,18 @@ import {
   estaConvocatoriaAbierta
 } from '@/data/admision'
 import { contactoAdmision } from '@/data/contacto'
+import { useScrollAnimation } from '@/hooks/useScrollAnimation'
 
 export const AdmissionCTA: React.FC = () => {
   const proceso = getProcesoActual()
   const estado = proceso ? calcularEstadoProceso(proceso) : 'cerrada'
   const convocatoriaAbierta = estaConvocatoriaAbierta()
   
+  const leftAnimation = useScrollAnimation()
+  const rightAnimation = useScrollAnimation({ threshold: 0.1 })
+  
   return (
     <section className="section-py px-4 sm:px-6 lg:px-8 bg-gradient-to-br from-blue-100 via-blue-50 to-blue-100 relative overflow-hidden">
-      {/* Decorative elements - subtle blue accents */}
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-blue-300 to-transparent" />
         <div className="absolute bottom-0 left-0 w-64 h-64 bg-blue-200/40 rounded-full -translate-x-1/2 translate-y-1/2 blur-2xl" />
@@ -26,7 +29,11 @@ export const AdmissionCTA: React.FC = () => {
       <div className="container-main relative z-10">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           {/* Left Content */}
-          <div>
+          <div
+            ref={leftAnimation.ref as React.RefObject<HTMLDivElement>}
+            className={`${leftAnimation.isVisible ? 'animate-fade-in-left' : 'opacity-0'}`}
+            style={{ animationDuration: '600ms', animationFillMode: 'forwards' }}
+          >
             <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium mb-6 ${
               convocatoriaAbierta 
                 ? 'bg-epg-navy text-white' 
@@ -86,8 +93,11 @@ export const AdmissionCTA: React.FC = () => {
           </div>
 
           {/* Right Content - Info Cards */}
-          <div className="grid gap-4">
-            <div className="bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50">
+          <div 
+            ref={rightAnimation.ref as React.RefObject<HTMLDivElement>}
+            className="grid gap-4"
+          >
+            <div className={`bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50 ${rightAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`} style={{ animationDelay: '0ms', animationDuration: '500ms', animationFillMode: 'forwards' }}>
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
                   <Calendar className="w-6 h-6 text-blue-800" />
@@ -109,7 +119,7 @@ export const AdmissionCTA: React.FC = () => {
               </div>
             </div>
 
-            <div className="bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50">
+            <div className={`bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50 ${rightAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`} style={{ animationDelay: '100ms', animationDuration: '500ms', animationFillMode: 'forwards' }}>
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
                   <FileText className="w-6 h-6 text-blue-800" />
@@ -128,7 +138,7 @@ export const AdmissionCTA: React.FC = () => {
               </div>
             </div>
 
-            <div className="bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50">
+            <div className={`bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow-sm border border-blue-200/50 ${rightAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`} style={{ animationDelay: '200ms', animationDuration: '500ms', animationFillMode: 'forwards' }}>
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
                   <Phone className="w-6 h-6 text-blue-800" />

--- a/src/features/home/components/FeaturedPrograms.tsx
+++ b/src/features/home/components/FeaturedPrograms.tsx
@@ -5,6 +5,7 @@ import { getProgramTypeConfig } from '@/lib/constants'
 import { SectionHeader } from '@/components/ui/section-header'
 import { LinkArrow } from '@/components/ui/link-arrow'
 import { ResourceCard } from '@/components/ui/resource-card'
+import { useScrollAnimation } from '@/hooks/useScrollAnimation'
 
 // Get featured programs from data
 const featuredPrograms = programas
@@ -34,11 +35,21 @@ export const FeaturedPrograms: React.FC = () => {
   const formacionContinuaCount = programas.filter(
     (p) => (p.tipo === 'diplomado' || p.tipo === 'curso') && p.estado === 'activo'
   ).length
+  
+  const headerAnimation = useScrollAnimation()
+  const cardsAnimation = useScrollAnimation({ threshold: 0.05 })
+  const categoriesAnimation = useScrollAnimation({ threshold: 0.1 })
+  
   return (
     <section className="section-py px-4 sm:px-6 lg:px-8 bg-gray-50">
       <div className="container-main">
         {/* Section Header */}
-        <SectionHeader
+        <div
+          ref={headerAnimation.ref as React.RefObject<HTMLDivElement>}
+          className={`${headerAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+          style={{ animationDuration: '600ms', animationFillMode: 'forwards' }}
+        >
+          <SectionHeader
           badge={{
             label: 'Nuestra oferta académica',
             className: 'text-epg-gold',
@@ -55,10 +66,14 @@ export const FeaturedPrograms: React.FC = () => {
             </a>
           }
         />
+        </div>
 
         {/* Programs Grid */}
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-          {displayPrograms.map((program) => {
+        <div 
+          ref={cardsAnimation.ref as React.RefObject<HTMLDivElement>}
+          className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
+        >
+          {displayPrograms.map((program, index) => {
             const typeConfig = getProgramTypeConfig(program.tipo)
             const Icon = typeConfig.icon || GraduationCap
 
@@ -66,7 +81,8 @@ export const FeaturedPrograms: React.FC = () => {
               <a
                 key={program.id}
                 href={`/programas/${program.slug}`}
-                className="group bg-white rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden border border-gray-100 hover:border-epg-gold/30"
+                className={`group bg-white rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden border border-gray-100 hover:border-epg-gold/30 ${cardsAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                style={{ animationDelay: `${index * 100}ms`, animationDuration: '500ms', animationFillMode: 'forwards' }}
               >
                 {/* Card Header with image or gradient */}
                 <div className="h-32 bg-gradient-to-br from-epg-navy to-epg-navy-light relative overflow-hidden">
@@ -163,26 +179,34 @@ export const FeaturedPrograms: React.FC = () => {
         </div>
 
         {/* Category Cards */}
-        <div className="grid md:grid-cols-3 gap-6 mt-12">
-          <ResourceCard
-            href="/programas/maestrias"
-            icon={GraduationCap}
-            title="Maestrías"
-            description={`${pluralize(maestriasCount, 'programa disponible', 'programas disponibles')} de 2 años para profesionales que buscan especialización.`}
-            variant="gradient-navy"
-          />
+        <div 
+          ref={categoriesAnimation.ref as React.RefObject<HTMLDivElement>}
+          className="grid md:grid-cols-3 gap-6 mt-12"
+        >
+          <div className={`${categoriesAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`} style={{ animationDelay: '0ms', animationDuration: '500ms', animationFillMode: 'forwards' }}>
+            <ResourceCard
+              href="/programas/maestrias"
+              icon={GraduationCap}
+              title="Maestrías"
+              description={`${pluralize(maestriasCount, 'programa disponible', 'programas disponibles')} de 2 años para profesionales que buscan especialización.`}
+              variant="gradient-navy"
+            />
+          </div>
 
-          <ResourceCard
-            href="/programas/doctorados"
-            icon={Award}
-            title="Doctorados"
-            description={`${pluralize(doctoradosCount, 'programa disponible', 'programas disponibles')} de investigación de alto nivel para líderes académicos.`}
-            variant="gradient-gold"
-          />
+          <div className={`${categoriesAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`} style={{ animationDelay: '100ms', animationDuration: '500ms', animationFillMode: 'forwards' }}>
+            <ResourceCard
+              href="/programas/doctorados"
+              icon={Award}
+              title="Doctorados"
+              description={`${pluralize(doctoradosCount, 'programa disponible', 'programas disponibles')} de investigación de alto nivel para líderes académicos.`}
+              variant="gradient-gold"
+            />
+          </div>
 
           <a
             href="/programas/formacion-continua"
-            className="group bg-white border-2 border-gray-200 hover:border-epg-gold rounded-lg p-6 text-epg-navy hover:shadow-xl transition-all"
+            className={`group bg-white border-2 border-gray-200 hover:border-epg-gold rounded-lg p-6 text-epg-navy hover:shadow-xl transition-all ${categoriesAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+            style={{ animationDelay: '200ms', animationDuration: '500ms', animationFillMode: 'forwards' }}
           >
             <BookOpen className="w-10 h-10 text-epg-gold mb-4" />
             <h3 className="text-xl font-bold mb-2">Formación Continua</h3>

--- a/src/features/home/components/NewsAndEvents.tsx
+++ b/src/features/home/components/NewsAndEvents.tsx
@@ -5,6 +5,7 @@ import { getPublicationTypeConfig } from '@/lib/constants'
 import { getDestacadas, getEventos } from '@/data/publicaciones'
 import { SectionHeader } from '@/components/ui/section-header'
 import { LinkArrow } from '@/components/ui/link-arrow'
+import { useScrollAnimation } from '@/hooks/useScrollAnimation'
 
 // Obtener publicaciones destacadas (máximo 3)
 const publications = getDestacadas().slice(0, 3)
@@ -16,26 +17,38 @@ const events = getEventos()
   .slice(0, 3)
 
 export const NewsAndEvents: React.FC = () => {
+  const headerAnimation = useScrollAnimation()
+  const newsAnimation = useScrollAnimation({ threshold: 0.1 })
+  const eventsAnimation = useScrollAnimation({ threshold: 0.1 })
+  
   return (
     <section className="section-py px-4 sm:px-6 lg:px-8 bg-white">
       <div className="container-main">
-        {/* Section Header */}
-        <SectionHeader
-          badge={{ label: 'Mantente informado', className: 'text-epg-gold' }}
-          title="Noticias y Eventos"
-          align="left"
-          action={
-            <a
-              href="/publicaciones"
-              className="inline-flex items-center gap-2 text-epg-navy font-semibold hover:text-epg-gold transition-colors group"
-            >
-              Ver todas las publicaciones
-              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-            </a>
-          }
-        />
+        <div
+          ref={headerAnimation.ref as React.RefObject<HTMLDivElement>}
+          className={`${headerAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+          style={{ animationDuration: '600ms', animationFillMode: 'forwards' }}
+        >
+          <SectionHeader
+            badge={{ label: 'Mantente informado', className: 'text-epg-gold' }}
+            title="Noticias y Eventos"
+            align="left"
+            action={
+              <a
+                href="/publicaciones"
+                className="inline-flex items-center gap-2 text-epg-navy font-semibold hover:text-epg-gold transition-colors group"
+              >
+                Ver todas las publicaciones
+                <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+              </a>
+            }
+          />
+        </div>
 
-        <div className="grid md:grid-cols-3 gap-6 md:gap-8">
+        <div 
+          ref={newsAnimation.ref as React.RefObject<HTMLDivElement>}
+          className="grid md:grid-cols-3 gap-6 md:gap-8"
+        >
           {/* Main News Column */}
           <div className="md:col-span-2 space-y-6">
             {publications.map((pub, index) => {
@@ -47,7 +60,8 @@ export const NewsAndEvents: React.FC = () => {
                   <a
                     key={pub.id}
                     href={`/publicaciones/${pub.slug}`}
-                    className="group block bg-gradient-to-br from-epg-navy to-epg-navy-light rounded-2xl overflow-hidden hover:shadow-xl transition-all"
+                    className={`group block bg-gradient-to-br from-epg-navy to-epg-navy-light rounded-2xl overflow-hidden hover:shadow-xl transition-all ${newsAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                    style={{ animationDelay: '0ms', animationDuration: '500ms', animationFillMode: 'forwards' }}
                   >
                     <div className="p-8">
                       <span
@@ -79,7 +93,8 @@ export const NewsAndEvents: React.FC = () => {
                 <a
                   key={pub.id}
                   href={`/publicaciones/${pub.slug}`}
-                  className="group flex gap-4 bg-gray-50 hover:bg-gray-100 rounded-xl p-4 transition-all"
+                  className={`group flex gap-4 bg-gray-50 hover:bg-gray-100 rounded-xl p-4 transition-all ${newsAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                  style={{ animationDelay: `${index * 100}ms`, animationDuration: '500ms', animationFillMode: 'forwards' }}
                 >
                   <div className="w-24 h-24 bg-gradient-to-br from-epg-navy to-epg-navy-light rounded-lg flex-shrink-0 flex items-center justify-center">
                     <Calendar className="w-8 h-8 text-epg-gold/50" />
@@ -103,7 +118,11 @@ export const NewsAndEvents: React.FC = () => {
           </div>
 
           {/* Events Sidebar */}
-          <div className="md:col-span-1 lg:sticky lg:top-4 self-start">
+          <div 
+            ref={eventsAnimation.ref as React.RefObject<HTMLDivElement>}
+            className={`md:col-span-1 lg:sticky lg:top-4 self-start ${eventsAnimation.isVisible ? 'animate-fade-in-right' : 'opacity-0'}`}
+            style={{ animationDuration: '600ms', animationFillMode: 'forwards' }}
+          >
             <div className="bg-gray-50 rounded-2xl p-6">
               <h3 className="font-bold text-epg-navy text-lg mb-6 flex items-center gap-2">
                 <Calendar className="w-5 h-5 text-epg-gold" />
@@ -111,14 +130,15 @@ export const NewsAndEvents: React.FC = () => {
               </h3>
 
               <div className="space-y-4">
-                {events.map((event) => {
+                {events.map((event, index) => {
                   const eventDate = formatEventDate(event.fechaEvento || event.fecha)
 
                   return (
                     <a
                       key={event.id}
                       href={`/publicaciones/${event.slug}`}
-                      className="flex gap-4 p-3 bg-white rounded-xl hover:shadow-md transition-all group"
+                      className={`flex gap-4 p-3 bg-white rounded-xl hover:shadow-md transition-all group ${eventsAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                      style={{ animationDelay: `${(index + 1) * 100}ms`, animationDuration: '400ms', animationFillMode: 'forwards' }}
                     >
                       {/* Date Badge */}
                       <div className="w-14 h-14 bg-epg-navy group-hover:bg-epg-gold rounded-lg flex flex-col items-center justify-center flex-shrink-0 transition-colors">

--- a/src/features/home/components/StatsSection.tsx
+++ b/src/features/home/components/StatsSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
   GraduationCap,
@@ -12,8 +12,8 @@ import { SectionHeader } from '@/components/ui/section-header';
 import { StatItem } from '@/components/ui/stat-item';
 import { IconCircle } from '@/components/ui/icon-circle';
 import { estadisticasInstitucionales } from '@/data/estadisticas';
+import { useScrollAnimation } from '@/hooks/useScrollAnimation';
 
-// Map icon names to Lucide components
 const iconMap: Record<string, LucideIcon> = {
   Calendar,
   Users,
@@ -23,40 +23,86 @@ const iconMap: Record<string, LucideIcon> = {
   ThumbsUp,
 };
 
+function AnimatedCounter({ value, isVisible }: { value: string; isVisible: boolean }) {
+  const [displayValue, setDisplayValue] = useState('0');
+  
+  useEffect(() => {
+    if (!isVisible) return;
+    
+    const numericMatch = value.match(/^(\d+)(\+)?$/);
+    if (!numericMatch) {
+      setDisplayValue(value);
+      return;
+    }
+    
+    const targetNumber = parseInt(numericMatch[1], 10);
+    const suffix = numericMatch[2] || '';
+    const duration = 2000;
+    const startTime = performance.now();
+    
+    const animate = (currentTime: number) => {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const easeOutQuart = 1 - Math.pow(1 - progress, 4);
+      const currentNumber = Math.floor(targetNumber * easeOutQuart);
+      
+      setDisplayValue(`${currentNumber.toLocaleString()}${suffix}`);
+      
+      if (progress < 1) {
+        requestAnimationFrame(animate);
+      }
+    };
+    
+    requestAnimationFrame(animate);
+  }, [isVisible, value]);
+  
+  return <>{displayValue}</>;
+}
+
 export const StatsSection: React.FC = () => {
+  const headerAnimation = useScrollAnimation();
+  const gridAnimation = useScrollAnimation({ threshold: 0.1 });
+  
   return (
     <section className="section-py px-4 sm:px-6 lg:px-8 bg-epg-navy relative overflow-hidden">
-      {/* Decorative elements */}
       <div className="absolute top-0 left-0 w-full h-full" aria-hidden="true">
         <div className="absolute top-10 left-10 w-64 h-64 bg-epg-gold/5 rounded-full blur-3xl" />
         <div className="absolute bottom-10 right-10 w-96 h-96 bg-epg-gold/5 rounded-full blur-3xl" />
       </div>
 
       <div className="max-w-7xl mx-auto relative z-10">
-        {/* Section Header */}
-        <SectionHeader
-          badge={{
-            label: 'Nuestros números',
-            className: 'text-epg-navy bg-epg-gold/80 px-2 py-1 rounded',
-          }}
-          title="Cifras que nos respaldan"
-          description="Más de tres décadas formando líderes para el desarrollo de la Amazonía peruana."
-          titleColor="text-white"
-          descriptionColor="text-gray-400"
-          className="mb-12"
-        />
+        <div
+          ref={headerAnimation.ref as React.RefObject<HTMLDivElement>}
+          className={`${headerAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+          style={{ animationDuration: '600ms', animationFillMode: 'forwards' }}
+        >
+          <SectionHeader
+            badge={{
+              label: 'Nuestros números',
+              className: 'text-epg-navy bg-epg-gold/80 px-2 py-1 rounded',
+            }}
+            title="Cifras que nos respaldan"
+            description="Más de tres décadas formando líderes para el desarrollo de la Amazonía peruana."
+            titleColor="text-white"
+            descriptionColor="text-gray-400"
+            className="mb-12"
+          />
+        </div>
 
-        {/* Stats Grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-4 md:gap-6">
+        <div 
+          ref={gridAnimation.ref as React.RefObject<HTMLDivElement>}
+          className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-4 md:gap-6"
+        >
           {estadisticasInstitucionales.map((stat, index) => {
             const Icon = iconMap[stat.icon];
             return (
               <div
                 key={stat.id}
-                className="p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 transition-all group"
+                className={`p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 transition-all group ${gridAnimation.isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                style={{ animationDelay: `${index * 80}ms`, animationDuration: '500ms', animationFillMode: 'forwards' }}
               >
                 <StatItem
-                  value={stat.value}
+                  value={<AnimatedCounter value={stat.value} isVisible={gridAnimation.isVisible} />}
                   label={stat.label}
                   description={stat.description}
                   variant="card"

--- a/src/hooks/useScrollAnimation.ts
+++ b/src/hooks/useScrollAnimation.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface UseScrollAnimationOptions {
+  threshold?: number
+  rootMargin?: string
+  triggerOnce?: boolean
+}
+
+export function useScrollAnimation(options: UseScrollAnimationOptions = {}) {
+  const { threshold = 0.1, rootMargin = '0px', triggerOnce = true } = options
+  const ref = useRef<HTMLElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          if (triggerOnce) {
+            observer.unobserve(element)
+          }
+        } else if (!triggerOnce) {
+          setIsVisible(false)
+        }
+      },
+      { threshold, rootMargin }
+    )
+
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [threshold, rootMargin, triggerOnce])
+
+  return { ref, isVisible }
+}
+
+export function useCountUp(end: number, duration: number = 2000, start: number = 0) {
+  const [count, setCount] = useState(start)
+  const { ref, isVisible } = useScrollAnimation()
+
+  useEffect(() => {
+    if (!isVisible) return
+
+    const startTime = performance.now()
+    const startValue = start
+    const endValue = end
+
+    const animate = (currentTime: number) => {
+      const elapsed = currentTime - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      
+      const easeOutQuart = 1 - Math.pow(1 - progress, 4)
+      const currentValue = Math.floor(startValue + (endValue - startValue) * easeOutQuart)
+      
+      setCount(currentValue)
+
+      if (progress < 1) {
+        requestAnimationFrame(animate)
+      }
+    }
+
+    requestAnimationFrame(animate)
+  }, [isVisible, end, duration, start])
+
+  return { ref, count }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -323,3 +323,122 @@
     @apply text-epg-gold font-medium text-sm inline-flex items-center gap-1 group-hover:gap-2 transition-all;
   }
 }
+
+/* Scroll Animations */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in-down {
+  from {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes fade-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in ease-out forwards;
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up ease-out forwards;
+}
+
+.animate-fade-in-down {
+  animation: fade-in-down ease-out forwards;
+}
+
+.animate-fade-in-left {
+  animation: fade-in-left ease-out forwards;
+}
+
+.animate-fade-in-right {
+  animation: fade-in-right ease-out forwards;
+}
+
+.animate-zoom-in {
+  animation: zoom-in ease-out forwards;
+}
+
+.animate-slide-up {
+  animation: slide-up ease-out forwards;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-fade-in-up,
+  .animate-fade-in-down,
+  .animate-fade-in-left,
+  .animate-fade-in-right,
+  .animate-zoom-in,
+  .animate-slide-up {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Resumen

Implementación de animaciones de scroll suaves y profesionales para todas las secciones del Home page.

## Cambios realizados

### Nuevos archivos
- **src/hooks/useScrollAnimation.ts**: Hook personalizado con Intersection Observer
- **src/components/ui/scroll-animation.tsx**: Componentes reutilizables para animaciones

### Animaciones implementadas

| Sección | Animación |
|---------|-----------|
| **Hero** | Sin animación (visible desde inicio) |
| **FeaturedPrograms** | Fade in con stagger en cards |
| **StatsSection** | Contadores animados + fade in con stagger |
| **NewsAndEvents** | Fade in + slide in de tarjetas |
| **AdmissionCTA** | Fade in desde izquierda y derecha |

### Tipos de animaciones CSS
- `fade-in`: Aparición gradual
- `fade-in-up`: Aparición desde abajo
- `fade-in-left/right`: Aparición desde los lados
- `zoom-in`: Escala desde pequeño

### Características
- **Performance**: Usando Intersection Observer nativo
- **Accesibilidad**: Soporte para `prefers-reduced-motion`
- **Stagger**: Animaciones secuenciales con delays
- **Contadores animados**: Números que cuentan hacia arriba

## Testing
- ✅ Build exitoso (43 páginas)
- ✅ Animaciones funcionan correctamente
- ✅ No afecta rendimiento

Closes #149