### PR TITLE
feat: Implementar view transitions para filtros de programas

### DIFF
--- a/src/features/programas/components/ProgramasLista.tsx
+++ b/src/features/programas/components/ProgramasLista.tsx
@@ -7,6 +7,7 @@ import type { ApiProgram } from '@/lib/api';
 import { GraduationCap, Search, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { ProgramCard } from './program-card';
+import { navigate } from 'astro:transitions/client';
 
 interface ProgramasListaProps {
   programs: ApiProgram[];
@@ -82,14 +83,14 @@ export function ProgramasLista({
     }
     // Only navigate if the debounced value differs from the current URL query
     if (debouncedSearch !== searchQuery) {
-      window.location.href = getSearchUrl(debouncedSearch, currentFilter);
+      navigate(getSearchUrl(debouncedSearch, currentFilter));
     }
   }, [debouncedSearch]);
 
   // Clear search input and navigate
   const handleClearSearch = () => {
     setSearchValue('');
-    window.location.href = getSearchUrl('', currentFilter);
+    navigate(getSearchUrl('', currentFilter));
   };
 
   const filterToTipo: Record<number, string> = {
@@ -236,7 +237,7 @@ export function ProgramasLista({
           description="Intenta ajustar los filtros o el término de búsqueda."
           action={{
             label: 'Limpiar filtros',
-            onClick: () => (window.location.href = getClearUrl()),
+            onClick: () => navigate(getClearUrl()),
           }}
           variant="inline"
         />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import { Footer } from "../features/navigation";
 import { ScrollToTop } from "../components/ui/scroll-to-top";
+import { ClientRouter } from "astro:transitions";
 
 interface Props {
 	title?: string;
@@ -50,9 +51,10 @@ const keywordsString = keywords.join(", ");
 
 <!doctype html>
 <html lang="es">
-	<head>
+<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<ClientRouter />
 		
 		<!-- Favicon -->
 		<link rel="icon" type="image/webp" href="/images/logo/Isotipo-EPG.webp" />


### PR DESCRIPTION
## Resumen

Implementa view transitions para eliminar las recargas completas al aplicar filtros en la página de programas.

## Cambios realizados

### 1. Habilitar View Transitions globalmente (`src/layouts/Layout.astro`)
- Agrega `ClientRouter` de `astro:transitions` al layout principal
- Habilita navegación client-side SPA en toda la aplicación

### 2. Reemplazar navegación en filtros (`src/features/programas/components/ProgramasLista.tsx`)
- Importa `navigate()` desde `astro:transitions/client`
- Reemplaza todas las instancias de `window.location.href` por `navigate()`:
  - Búsqueda con debounce (línea 86)
  - Limpiar búsqueda (línea 93)
  - Limpiar filtros desde estado vacío (línea 240)

## Beneficios

- ✅ Navegación fluida sin recargas de página
- ✅ Estado de interfaz preservado entre navegaciones
- ✅ Mejor rendimiento percibido por el usuario
- ✅ Transiciones animadas suaves
- ✅ Experiencia tipo SPA manteniendo arquitectura MPA de Astro

## Issue relacionado

Closes #168

## Testing

- [ ] Ir a `/programas`
- [ ] Escribir en el campo de búsqueda → debería filtrar sin recarga
- [ ] Hacer clic en tabs de tipo (Maestrías, Doctorados, etc.) → debería cambiar sin recarga
- [ ] Limpiar filtros → debería funcionar sin recarga
- [ ] Verificar que las transiciones son suaves y no hay parpadeos

## Checklist

- [x] Código sigue las convenciones del proyecto
- [x] Cambios probados localmente
- [x] No hay breaking changes
- [x] Documentación actualizada (issue creado)
