### PR TITLE
feat: Agregar componente ScrollReveal para animaciones al scroll

### DIFF
--- a/src/components/ui/scroll-reveal.astro
+++ b/src/components/ui/scroll-reveal.astro
@@ -1,0 +1,93 @@
+---
+interface Props {
+  animation?: 'fade-in' | 'fade-in-up' | 'fade-in-down' | 'fade-in-left' | 'fade-in-right' | 'slide-in-up' | 'slide-in-down' | 'slide-in-left' | 'slide-in-right' | 'zoom-in' | 'zoom-in-up';
+  delay?: number;
+  duration?: number;
+  threshold?: number;
+  once?: boolean;
+  class?: string;
+}
+
+const {
+  animation = 'fade-in-up',
+  delay = 0,
+  duration = 600,
+  threshold = 0.1,
+  once = true,
+  class: className = '',
+} = Astro.props;
+
+const animationMap: Record<string, string> = {
+  'fade-in': 'animate-fade-in',
+  'fade-in-up': 'animate-fade-in-up',
+  'fade-in-down': 'animate-fade-in-down',
+  'fade-in-left': 'animate-fade-in-left',
+  'fade-in-right': 'animate-fade-in-right',
+  'slide-in-up': 'animate-slide-in-from-bottom',
+  'slide-in-down': 'animate-slide-in-from-top',
+  'slide-in-left': 'animate-slide-in-from-right',
+  'slide-in-right': 'animate-slide-in-from-left',
+  'zoom-in': 'animate-zoom-in',
+  'zoom-in-up': 'animate-zoom-in-up',
+};
+---
+
+<div
+  class:list={['scroll-reveal', className]}
+  data-animation={animationMap[animation]}
+  data-delay={delay}
+  data-duration={duration}
+  data-threshold={threshold}
+  data-once={once}
+>
+  <slot />
+</div>
+
+<script>
+  function initScrollReveal() {
+    const elements = document.querySelectorAll('.scroll-reveal');
+    
+    if (elements.length === 0) return;
+
+    elements.forEach((element) => {
+      const el = element as HTMLElement;
+      const animation = el.dataset.animation || 'animate-fade-in-up';
+      const delay = parseInt(el.dataset.delay || '0', 10);
+      const duration = parseInt(el.dataset.duration || '600', 10);
+      const threshold = parseFloat(el.dataset.threshold || '0.1');
+      const once = el.dataset.once !== 'false';
+
+      el.style.opacity = '0';
+      el.style.transitionDuration = `${duration}ms`;
+      el.style.transitionDelay = `${delay}ms`;
+      el.style.transitionProperty = 'opacity, transform';
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              el.classList.add(animation);
+              el.style.opacity = '1';
+              
+              if (once) {
+                observer.unobserve(entry.target);
+              }
+            } else if (!once) {
+              el.classList.remove(animation);
+              el.style.opacity = '0';
+            }
+          });
+        },
+        { threshold }
+      );
+
+      observer.observe(el);
+    });
+  }
+
+  document.addEventListener('astro:page-load', initScrollReveal);
+  
+  if (document.readyState === 'complete') {
+    initScrollReveal();
+  }
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -331,4 +331,18 @@
   .link-arrow {
     @apply text-epg-gold font-medium text-sm inline-flex items-center gap-1 group-hover:gap-2 transition-all;
   }
+
+  /* Scroll Reveal - animaciones al hacer scroll */
+  .scroll-reveal {
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    will-change: opacity, transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-reveal {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+  }
 }


### PR DESCRIPTION
## Resumen

Agrega componente `ScrollReveal` para animaciones de scroll usando Intersection Observer API nativo.

## Cambios realizados

### Nuevo componente `ScrollReveal.astro`

Componente Astro reutilizable que detecta cuando los elementos entran en el viewport y aplica animaciones CSS suaves.

**Props disponibles:**
| Prop | Tipo | Default | Descripción |
|------|------|---------|-------------|
| `animation` | string | `'fade-in-up'` | Tipo de animación |
| `delay` | number | `0` | Delay en ms |
| `duration` | number | `600` | Duración en ms |
| `threshold` | number | `0.1` | Porcentaje visible para disparar |
| `once` | boolean | `true` | Si solo anima una vez |
| `class` | string | `''` | Clases adicionales |

**Animaciones disponibles:**
- `fade-in`, `fade-in-up`, `fade-in-down`, `fade-in-left`, `fade-in-right`
- `slide-in-up`, `slide-in-down`, `slide-in-left`, `slide-in-right`
- `zoom-in`, `zoom-in-up`

### Estilos CSS

Agregados en `global.css`:
- Estilos base para transiciones suaves
- Soporte para `prefers-reduced-motion`

## Ejemplo de uso

```astro
---
import ScrollReveal from '@/components/ui/scroll-reveal.astro';
---

<ScrollReveal animation="fade-in-up">
  <h2>Título animado</h2>
</ScrollReveal>

<ScrollReveal animation="slide-in-left" delay={100}>
  <p>Contenido con delay</p>
</ScrollReveal>

<ScrollReveal animation="zoom-in" duration={800}>
  <img src="hero.jpg" alt="Hero" />
</ScrollReveal>
```

## Características

- Sin dependencias externas
- Performante (Intersection Observer es async)
- Accesible (respeta prefers-reduced-motion)
- Compatible con view transitions de Astro
- Integrado con tw-animate-css existente

## Issue relacionado

Closes #170

## Checklist

- [x] Código sigue convenciones del proyecto
- [x] Componente reutilizable
- [x] Soporte para accesibilidad (prefers-reduced-motion)
- [x] Compatible con view transitions
