### PR TITLE
fix: add .env.local to gitignore and remove from tracking (closes #184)

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,6 +1,0 @@
-# API Configuration
-API_BASE_URL=https://api.postgradounap.edu.pe
-API_TIMEOUT=10000
-
-# Note: These variables are used server-side only
-# For client-side public variables, use PUBLIC_ prefix.

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
 .env.production
+.env.*.local
 
 # macOS-specific files
 .DS_Store


### PR DESCRIPTION
## Summary

- Agrega `.env.local` y `.env.*.local` al `.gitignore`
- Remueve `.env.local` del tracking de git (`git rm --cached`)
- Previene que datos sensibles sean commiteados al repositorio

## Changes

- `.gitignore`: Agregadas reglas para `.env.local` y `.env.*.local`
- `.env.local`: Removido del tracking (el archivo local permanece en el filesystem)

## Testing

- Verificar que `.env.local` sigue existiendo localmente
- Verificar que `.gitignore` ahora ignora `.env.local`
- Verificar que `git status` no muestra `.env.local` como unstaged

## Related Issue

Fixes #184