### PR TITLE
feat: Agregar React Error Boundaries para islands hidratados

### DIFF
--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,0 +1,149 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "./button"
+import { AlertTriangle, RefreshCw } from "lucide-react"
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("ErrorBoundary caught an error:", error, errorInfo)
+    this.props.onError?.(error, errorInfo)
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div
+          className={cn(
+            "flex flex-col items-center justify-center",
+            "min-h-[200px] p-6 text-center",
+            "bg-destructive/10 border border-destructive/20 rounded-lg",
+            "text-destructive"
+          )}
+        >
+          <AlertTriangle className="h-10 w-10 mb-4" />
+          <h3 className="text-lg font-semibold mb-2">
+            Algo salió mal
+          </h3>
+          <p className="text-sm mb-4 text-muted-foreground">
+            {this.state.error?.message || "Ha ocurrido un error inesperado"}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={this.handleReset}
+            className="gap-2"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Reintentar
+          </Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+interface AsyncErrorBoundaryProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+  onError?: (error: Error) => void
+}
+
+interface AsyncErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class AsyncErrorBoundary extends React.Component<
+  AsyncErrorBoundaryProps,
+  AsyncErrorBoundaryState
+> {
+  constructor(props: AsyncErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("AsyncErrorBoundary caught an error:", error, errorInfo)
+    this.props.onError?.(error)
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div
+          className={cn(
+            "flex flex-col items-center justify-center",
+            "min-h-[200px] p-6 text-center",
+            "bg-destructive/10 border border-destructive/20 rounded-lg",
+            "text-destructive"
+          )}
+        >
+          <AlertTriangle className="h-10 w-10 mb-4" />
+          <h3 className="text-lg font-semibold mb-2">
+            Error al cargar datos
+          </h3>
+          <p className="text-sm mb-4 text-muted-foreground">
+            {this.state.error?.message || "No se pudieron cargar los datos"}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={this.handleReset}
+            className="gap-2"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Reintentar
+          </Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import Footer from "../features/navigation/components/Footer.astro";
 import ScrollToTop from "../components/ui/ScrollToTop.astro";
 import { FloatingContactButton } from "../components/ui/floating-contact-button";
+import { ErrorBoundary } from "../components/ui/error-boundary";
 import { ClientRouter } from "astro:transitions";
 
 interface Props {
@@ -151,7 +152,9 @@ const keywordsString = keywords.join(", ");
 		<slot />
 		<Footer />
 		<ScrollToTop />
-		<FloatingContactButton client:load />
+		<ErrorBoundary client:load>
+			<FloatingContactButton />
+		</ErrorBoundary>
 		<script>
 			import "../scripts/scroll-reveal";
 		</script>

--- a/src/pages/contacto/index.astro
+++ b/src/pages/contacto/index.astro
@@ -4,6 +4,7 @@ import Navbar from '../../features/navigation/components/Navbar.astro';
 import { ContactForm } from '../../features/contacto';
 import { contactoGeneral } from '../../data/contacto';
 import { FORMSPREE_ID } from 'astro:env/server';
+import { ErrorBoundary } from '../../components/ui/error-boundary';
 ---
 
 <Layout 
@@ -29,7 +30,9 @@ import { FORMSPREE_ID } from 'astro:env/server';
         <div class="grid lg:grid-cols-3 gap-12">
           <!-- Contact Form -->
           <div class="lg:col-span-2">
-            <ContactForm formspreeId={FORMSPREE_ID} client:load />
+            <ErrorBoundary client:load>
+              <ContactForm formspreeId={FORMSPREE_ID} />
+            </ErrorBoundary>
           </div>
 
           <!-- Contact Info -->

--- a/src/pages/programas/[slug].astro
+++ b/src/pages/programas/[slug].astro
@@ -5,6 +5,7 @@ import { ProgramaDetail } from '../../features/programas';
 import { programas, getProgramaBySlug } from '../../data/programas';
 import { getProgramBySlug } from '../../lib/api/programs';
 import type { Programa } from '../../types/programas';
+import { ErrorBoundary } from '../../components/ui/error-boundary';
 
 export async function getStaticPaths() {
   return programas.map((programa) => ({
@@ -65,6 +66,8 @@ const tipoLabels: Record<string, string> = {
 >
   <Navbar />
   <main>
-    <ProgramaDetail programa={programaData} client:load />
+    <ErrorBoundary client:load>
+      <ProgramaDetail programa={programaData} />
+    </ErrorBoundary>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary

Agrega Error Boundaries para evitar pantallas blancas cuando los componentes React hidratados fallan en runtime.

## Changes

**Nuevo componente:**
- `src/components/ui/error-boundary.tsx` — ErrorBoundary y AsyncErrorBoundary
  - UI de fallback amigable con icono de alerta
  - Botón de "Reintentar" para recuperación
  - Logging de errores para debugging
  - Props: `children`, `fallback`, `onError`

**Islands envueltos:**
- `src/layouts/Layout.astro` — FloatingContactButton
- `src/pages/contacto/index.astro` — ContactForm
- `src/pages/programas/[slug].astro` — ProgramaDetail

## Testing

- Build exitoso: `pnpm build`
- Tests pasando: `pnpm test:run` (61/61 tests)

## Checklist

- [x] Componente ErrorBoundary creado
- [x] UI de fallback amigable (no pantalla blanca)
- [x] Islands principales envueltos
- [x] El proyecto compila sin errores
- [x] Los tests pasan

Fixes #199