### PR TITLE
fix: Eliminar barrel export innecesario de navigation/index.ts

### DIFF
--- a/src/features/navigation/index.ts
+++ b/src/features/navigation/index.ts
@@ -1,1 +1,0 @@
-export { Navbar } from './components/Navbar';


### PR DESCRIPTION
## Summary

Elimina el barrel export `src/features/navigation/index.ts` que no se usaba y causaba confusión.

## Changes

- Eliminado `src/features/navigation/index.ts`
- Las páginas importan `Navbar` directamente desde el archivo `.astro`

## Reason

El barrel export referenciaba `Navbar` desde `./components/Navbar`, pero:
1. No existe `Navbar.tsx` (solo existe `Navbar.astro`)
2. Ninguna página usa el barrel export (importan directamente desde `.astro`)

Opción A seleccionada: eliminar el barrel export para mantener el código limpio.

## Testing

- Build exitoso: `pnpm build`
- Tests pasando: `pnpm test:run` (61/61 tests)

## Checklist

- [x] Barrel export eliminado
- [x] No hay imports rotos
- [x] El proyecto compila sin errores
- [x] Los tests pasan

Fixes #200