### PR TITLE
perf: Self-host Google Fonts con @fontsource/inter

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@astrojs/node": "^9.5.4",
     "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.0",
+    "@fontsource/inter": "^5.2.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.7.0
         version: 3.7.0
+      '@fontsource/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -430,6 +433,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource/inter@5.2.8':
+    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -3769,6 +3775,8 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource/inter@5.2.8': {}
 
   '@img/colour@1.0.0':
     optional: true

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,12 @@
 ---
 import "../styles/global.css";
+import "@fontsource/inter/300.css";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/inter/800.css";
+import "@fontsource/inter/900.css";
 import Footer from "../features/navigation/components/Footer.astro";
 import ScrollToTop from "../components/ui/ScrollToTop.astro";
 import { FloatingContactButton } from "../components/ui/floating-contact-button";
@@ -62,11 +69,6 @@ const keywordsString = keywords.join(", ");
 		<link rel="icon" type="image/webp" href="/images/logo/Isotipo-EPG.webp" />
 		<link rel="icon" type="image/webp" sizes="32x32" href="/images/logo/Isotipo-EPG.webp" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/images/logo/Isotipo-EPG.webp" />
-		
-		<!-- Google Fonts - Inter -->
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
 		
 		<!-- Primary Meta Tags -->
 		<title>{fullTitle}</title>


### PR DESCRIPTION
## Summary

Reemplaza la carga externa de Google Fonts con la fuente Inter cargada localmente usando `@fontsource/inter`.

## Changes

- Instalado `@fontsource/inter` como dependencia
- Removidos los `<link>` externos a Google Fonts del `<head>`
- Agregados imports de CSS de la fuente en el frontmatter de Layout.astro
- Pesos incluidos: 300, 400, 500, 600, 700, 800, 900

## Beneficios

- **Sin requests externos** a `fonts.googleapis.com`
- **Mejor performance** — fuente servida desde el mismo dominio
- **Mayor privacidad** — sin tracking de Google
- **Alta disponibilidad** — no depende de servicios externos

## Testing

- Build exitoso: `pnpm build`
- Tests pasando: `pnpm test:run` (61/61 tests)

## Checklist

- [x] Google Fonts removido del `<head>`
- [x] Fuente Inter cargada localmente
- [x] No hay requests externos a `fonts.googleapis.com`
- [x] El proyecto compila sin errores
- [x] Los tests pasan

Fixes #202