### PR TITLE
fix: align programas detail slug resolution and API mapping (#228)

### DIFF
--- a/src/features/programas/components/ProgramaDetail.tsx
+++ b/src/features/programas/components/ProgramaDetail.tsx
@@ -1,8 +1,8 @@
 import type { Programa } from '@/types';
 import { formatDateSafe } from '@/lib/formatters';
 import {
-  tipoProgramaLabels,
   tipoProgramaColors,
+  tipoProgramaTextLabels,
   modalidadLabels,
   modalidadColors,
 } from '@/lib/config';
@@ -40,10 +40,15 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
     <div className="min-h-screen bg-gray-50">
       {/* Hero Header */}
       <PageHero
+        breadcrumbs={[
+          { label: 'Inicio', href: '/' },
+          { label: 'Programas', href: '/programas' },
+          { label: programa.nombre },
+        ]}
         title={programa.nombre}
         subtitle={programa.descripcionCorta}
         badge={{
-          label: tipoProgramaLabels[programa.tipo],
+          label: tipoProgramaTextLabels[programa.tipo],
           className: 'bg-white/20 text-white hover:bg-white/30',
         }}
         bgColorClass={tipoProgramaColors[programa.tipo]}
@@ -188,7 +193,7 @@ export function ProgramaDetail({ programa }: ProgramaDetailProps) {
                   <div>
                     <p className="text-sm text-gray-500">Tipo de Programa</p>
                     <p className="font-medium">
-                      {tipoProgramaLabels[programa.tipo]}
+                      {tipoProgramaTextLabels[programa.tipo]}
                     </p>
                   </div>
                 </div>

--- a/src/lib/api/programs/client.ts
+++ b/src/lib/api/programs/client.ts
@@ -4,6 +4,7 @@
  */
 
 import { buildQueryString, endpoints, fetchApi } from '../shared';
+import { getProgramRouteParam } from '@/lib/program-slugs';
 import type { ApiProgram, ProgramFilters } from './types';
 
 export async function getPrograms(
@@ -19,8 +20,12 @@ export async function getProgramBySlug(
   slug: string
 ): Promise<ApiProgram | undefined> {
   try {
-    const programs = await getPrograms({ search: slug, is_active: true });
-    return programs.find((p) => p.uuid === slug || p.name.toLowerCase().includes(slug.toLowerCase()));
+    const programs = await getPrograms({ is_active: true });
+    return programs.find(
+      (program) =>
+        program.uuid === slug ||
+        getProgramRouteParam({ name: program.name }) === slug
+    );
   } catch {
     return undefined;
   }

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -17,6 +17,7 @@ export {
   tipoProgramaBadgeColors,
   tipoProgramaColors,
   tipoProgramaLabels,
+  tipoProgramaTextLabels,
 } from './program-types';
 
 export type { ProgramTypeConfig } from './program-types';

--- a/src/lib/config/program-types.ts
+++ b/src/lib/config/program-types.ts
@@ -56,6 +56,13 @@ export const tipoProgramaLabels: Record<number, string> = {
   4: 'Curso',
 };
 
+export const tipoProgramaTextLabels: Record<string, string> = {
+  maestria: 'Maestría',
+  doctorado: 'Doctorado',
+  diplomado: 'Diplomado',
+  curso: 'Curso',
+};
+
 // Colores de fondo para tipos de programa
 export const tipoProgramaColors: Record<string, string> = {
   maestria: 'bg-maestria',

--- a/src/lib/program-mappers.ts
+++ b/src/lib/program-mappers.ts
@@ -1,0 +1,64 @@
+import { getProgramaBySlug } from '@/data/programas'
+import { getProgramRouteParam } from '@/lib/program-slugs'
+import type { ApiProgram } from '@/lib/api/programs/types'
+import type { Programa, TipoPrograma } from '@/types/programas'
+
+const apiProgramTypeMap: Record<number, TipoPrograma> = {
+  1: 'maestria',
+  2: 'doctorado',
+  3: 'diplomado',
+  4: 'curso',
+}
+
+export function mapApiProgramType(programType: number): TipoPrograma {
+  return apiProgramTypeMap[programType] ?? 'curso'
+}
+
+export function createShortDescription(
+  description: string,
+  maxLength: number = 100,
+): string {
+  if (description.length <= maxLength) {
+    return description
+  }
+
+  return `${description.slice(0, maxLength).trimEnd()}...`
+}
+
+export function findMockProgramForApiProgram(
+  apiProgram: Pick<ApiProgram, 'name'>,
+): Programa | undefined {
+  const slug = getProgramRouteParam({ name: apiProgram.name })
+  return getProgramaBySlug(slug)
+}
+
+export function mapApiProgramToPrograma(
+  apiProgram: ApiProgram,
+  fallbackProgram?: Programa,
+): Programa {
+  const matchedProgram = fallbackProgram ?? findMockProgramForApiProgram(apiProgram)
+  const slug = matchedProgram?.slug ?? getProgramRouteParam({ name: apiProgram.name })
+  const tipo = matchedProgram?.tipo ?? mapApiProgramType(apiProgram.program_type)
+
+  return {
+    id: matchedProgram?.id ?? String(apiProgram.id),
+    nombre: apiProgram.name,
+    tipo,
+    descripcion: apiProgram.description,
+    descripcionCorta:
+      matchedProgram?.descripcionCorta ?? createShortDescription(apiProgram.description),
+    duracion: matchedProgram?.duracion ?? 'Por definir',
+    creditos: matchedProgram?.creditos ?? 0,
+    modalidad: matchedProgram?.modalidad ?? 'presencial',
+    estado: apiProgram.is_active ? 'activo' : 'inactivo',
+    fechaInicio: matchedProgram?.fechaInicio,
+    imagen: matchedProgram?.imagen ?? apiProgram.background,
+    slug,
+    facultad: matchedProgram?.facultad ?? 'Por definir',
+    requisitos: matchedProgram?.requisitos,
+    planEstudios: matchedProgram?.planEstudios,
+    coordinador: matchedProgram?.coordinador,
+    inversion: matchedProgram?.inversion,
+    destacado: matchedProgram?.destacado,
+  }
+}

--- a/src/pages/programas/[slug].astro
+++ b/src/pages/programas/[slug].astro
@@ -1,49 +1,27 @@
 ---
+export const prerender = false;
+
 import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';
 import { ProgramaDetail } from '../../features/programas';
-import { programas, getProgramaBySlug } from '../../data/programas';
+import { getProgramaBySlug } from '../../data/programas';
 import { getProgramBySlug } from '../../lib/api/programs';
+import { mapApiProgramToPrograma } from '../../lib/program-mappers';
 import type { Programa } from '../../types/programas';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
 
-export async function getStaticPaths() {
-  return programas.map((programa) => ({
-    params: { slug: programa.slug },
-    props: { programa },
-  }));
-}
-
 const { slug } = Astro.params;
-const { programa: programaFromProps } = Astro.props;
+let programaData: Programa | undefined = slug ? getProgramaBySlug(slug) : undefined;
 
-let programaData: Programa | undefined = programaFromProps;
-
-if (!programaData) {
+if (slug) {
   try {
-    const apiProgram = await getProgramBySlug(slug!);
+    const apiProgram = await getProgramBySlug(slug);
     if (apiProgram) {
-      programaData = {
-        id: String(apiProgram.id),
-        nombre: apiProgram.name,
-        tipo: 'maestria',
-        descripcion: apiProgram.description,
-        descripcionCorta: apiProgram.description.slice(0, 100),
-        duracion: 'Por definir',
-        creditos: 0,
-        modalidad: 'presencial',
-        estado: apiProgram.is_active ? 'activo' : 'inactivo',
-        slug: apiProgram.uuid,
-        facultad: 'Por definir',
-      };
+      programaData = mapApiProgramToPrograma(apiProgram, programaData);
     }
   } catch {
-    programaData = getProgramaBySlug(slug!);
+    programaData = slug ? getProgramaBySlug(slug) : undefined;
   }
-}
-
-if (!programaData) {
-  programaData = getProgramaBySlug(slug!);
 }
 
 if (!programaData) {


### PR DESCRIPTION
## Summary
- align `/programas/[slug]` with the slug strategy introduced for program cards so detail resolution no longer depends on fragile name matching
- replace the hardcoded API-to-detail mapping with a dedicated mapper that preserves useful mock metadata when the API lacks fields like duration, credits, faculty, or coordinator
- fix the program type label rendering in `ProgramaDetail` and provide the required breadcrumbs for `PageHero`

## Validation
- verified `/programas/maestria-gestion-publica` resolves correctly and shows the right program type label
- `pnpm build` reaches route generation successfully; the remaining failure is the known Windows `@astrojs/vercel` symlink issue at the final packaging step