### PR TITLE
fix: replace dead navbar links with valid destinations (#227)

### DIFF
--- a/src/features/navigation/components/Navbar.astro
+++ b/src/features/navigation/components/Navbar.astro
@@ -29,9 +29,9 @@ const secondaryNavItems: DropdownItem[] = [
     href: '/publicaciones',
     items: [
       { label: 'Todas las publicaciones', href: '/publicaciones' },
-      { label: 'Noticias', href: '/publicaciones/noticias' },
-      { label: 'Eventos', href: '/publicaciones/eventos' },
-      { label: 'Avisos', href: '/publicaciones/avisos' },
+      { label: 'Noticias', href: '/publicaciones' },
+      { label: 'Eventos', href: '/publicaciones' },
+      { label: 'Avisos', href: '/publicaciones' },
     ],
   },
   {
@@ -39,8 +39,8 @@ const secondaryNavItems: DropdownItem[] = [
     href: '/docentes',
     items: [
       { label: 'Nuestros Docentes', href: '/docentes' },
-      { label: 'Recursos Docentes', href: '/docentes/recursos' },
-      { label: 'Calendario Académico', href: '/docentes/calendario' },
+      { label: 'Recursos Docentes', href: '/docentes' },
+      { label: 'Calendario Académico', href: '/docentes' },
     ],
   },
   {
@@ -48,9 +48,9 @@ const secondaryNavItems: DropdownItem[] = [
     href: '/estudiantes',
     items: [
       { label: 'Portal del Estudiante', href: '/estudiantes' },
-      { label: 'Matrícula', href: '/estudiantes/matricula' },
-      { label: 'Trámite de Grado', href: '/estudiantes/tramite-grado' },
-      { label: 'Sustentaciones', href: '/estudiantes/sustentaciones' },
+      { label: 'Matrícula', href: '/estudiantes' },
+      { label: 'Trámite de Grado', href: '/estudiantes' },
+      { label: 'Sustentaciones', href: '/estudiantes' },
     ],
   },
   {
@@ -58,9 +58,9 @@ const secondaryNavItems: DropdownItem[] = [
     href: '/servicios',
     items: [
       { label: 'Todos los Servicios', href: '/servicios' },
-      { label: 'SIGAE', href: 'https://sigae.universidad.edu.pe', isExternal: true },
-      { label: 'Aula Virtual', href: 'https://aulavirtual.universidad.edu.pe', isExternal: true },
-      { label: 'Biblioteca Virtual', href: 'https://biblioteca.universidad.edu.pe', isExternal: true },
+      { label: 'SIGAE', href: 'https://sigae.unapiquitos.edu.pe', isExternal: true },
+      { label: 'Aula Virtual', href: 'https://aulavirtual.unapiquitos.edu.pe', isExternal: true },
+      { label: 'Biblioteca Virtual', href: 'https://biblioteca.unapiquitos.edu.pe', isExternal: true },
       { label: 'Correo Institucional', href: 'https://outlook.office.com', isExternal: true },
     ],
   },


### PR DESCRIPTION
## Summary
- replace dead internal Navbar routes with existing destinations so the menu no longer points to pages that do not exist
- keep the current navigation structure intact by redirecting submenu items to their parent section pages where dedicated subroutes are not implemented yet
- update the external service links in the Navbar to use the real institutional domains already referenced elsewhere in the project

## Validation
- reviewed the Navbar routes against the current `src/pages` structure to ensure each internal link resolves to an existing page
- `pnpm build` completes route generation successfully; the only remaining failure is the known Windows `@astrojs/vercel` symlink issue during final packaging