### PR TITLE
fix: replace dead footer links with valid destinations (#226)

### DIFF
--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -15,28 +15,28 @@ import {
 
 const footerLinks = {
   programas: [
-    { label: 'Maestrías', href: '/programas/maestrias' },
-    { label: 'Doctorados', href: '/programas/doctorados' },
-    { label: 'Diplomados', href: '/programas/diplomados' },
-    { label: 'Cursos', href: '/programas/cursos' },
+    { label: 'Maestrías', href: '/programas' },
+    { label: 'Doctorados', href: '/programas' },
+    { label: 'Diplomados', href: '/programas' },
+    { label: 'Cursos', href: '/programas' },
   ],
   laEscuela: [
     { label: 'Presentación', href: '/escuela' },
     { label: 'Autoridades', href: '/escuela/autoridades' },
-    { label: 'Directorio', href: '/escuela/directorio' },
+    { label: 'Directorio', href: '/escuela/documentos' },
     { label: 'Contacto', href: '/contacto' },
   ],
   estudiantes: [
     { label: 'Portal del Estudiante', href: '/estudiantes' },
-    { label: 'Trámites', href: '/estudiantes/tramites' },
-    { label: 'Sustentaciones', href: '/estudiantes/sustentaciones' },
-    { label: 'Biblioteca', href: '/servicios/biblioteca-virtual' },
+    { label: 'Trámites', href: '/estudiantes' },
+    { label: 'Sustentaciones', href: '/estudiantes' },
+    { label: 'Biblioteca', href: '/servicios' },
   ],
   servicios: [
-    { label: 'SIGAE', href: '/servicios/sigae' },
-    { label: 'Aula Virtual', href: '/servicios/aula-virtual' },
-    { label: 'Correo Institucional', href: '/servicios/correo-institucional' },
-    { label: 'Mesa de Partes', href: '/servicios/mesa-partes' },
+    { label: 'SIGAE', href: '/servicios' },
+    { label: 'Aula Virtual', href: '/servicios' },
+    { label: 'Correo Institucional', href: '/servicios' },
+    { label: 'Mesa de Partes', href: '/servicios' },
   ],
 };
 
@@ -211,13 +211,13 @@ const currentYear = new Date().getFullYear();
         </div>
         <div class="flex items-center gap-4 text-sm text-gray-400">
           <a
-            href="/politica-privacidad"
+            href="/contacto"
             class="hover:text-white transition-colors"
           >
             Política de Privacidad
           </a>
           <a
-            href="/terminos-condiciones"
+            href="/contacto"
             class="hover:text-white transition-colors"
           >
             Términos y Condiciones


### PR DESCRIPTION
## Summary
- replace dead internal Footer routes with existing destinations so the footer no longer points to non-existent pages
- preserve the current footer structure by redirecting category links to valid section pages while dedicated subroutes do not exist yet
- avoid 404s for the legal links by pointing them to `/contacto` until dedicated legal pages are implemented

## Validation
- checked the updated footer routes against the current `src/pages` structure to ensure the broken links were removed
- `pnpm build` completes route generation successfully; the only remaining failure is the known Windows `@astrojs/vercel` symlink issue during final packaging