### PR TITLE
fix: correct admission CTAs and institutional copy (#233)

### DIFF
--- a/src/features/admision/components/AdmisionContent.tsx
+++ b/src/features/admision/components/AdmisionContent.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { convocatorias, fechasImportantes } from '@/data/convocatorias'
+import { contactoAdmision, getEmailHref } from '@/data/contacto'
 import { programas, getProgramaBySlug } from '@/data/programas'
 import { formatShortDate } from '@/lib/formatters'
 import {
   tipoFechaAdmisionColors,
   tipoFechaAdmisionLabels,
-  tipoProgramaBadgeColors,
+  tipoProgramaTextBadgeColors,
+  tipoProgramaTextLabels,
 } from '@/lib/config'
 import {
   Calendar,
@@ -581,8 +583,8 @@ function ProgramasVacantes() {
             href={`/programas/${slug}`}
             className="group bg-white rounded-lg border p-4 hover:shadow-lg hover:border-epg-gold transition-all"
           >
-            <Badge className={tipoProgramaBadgeColors[programa.tipo]}>
-              {programa.tipo === 'maestria' ? 'Maestría' : 'Doctorado'}
+            <Badge className={tipoProgramaTextBadgeColors[programa.tipo]}>
+              {tipoProgramaTextLabels[programa.tipo]}
             </Badge>
             <h3 className="font-semibold text-gray-900 mt-2 group-hover:text-epg-navy line-clamp-2">
               {programa.nombre
@@ -718,19 +720,19 @@ export function AdmisionContent() {
           description="Únete a la comunidad de profesionales que eligen la EPG UNAP para su formación de posgrado. Las inscripciones cierran el 28 de febrero de 2025."
           primaryAction={{
             label: 'Inscripción en línea',
-            href: '#',
+            href: '/contacto',
             icon: <ExternalLink className="h-5 w-5 mr-2" />,
           }}
           secondaryAction={{
             label: 'Contactar asesor',
-            href: '#',
+            href: getEmailHref(contactoAdmision.email),
             icon: <HelpCircle className="h-5 w-5 mr-2" />,
           }}
           footer={
             <div className="flex items-center justify-center gap-4 text-sm text-gray-400">
               <div className="flex items-center gap-2">
                 <MapPin className="h-4 w-4" />
-                <span>Ciudad Universitaria, Puno</span>
+                <span>Iquitos, Loreto</span>
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="h-4 w-4" />

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -17,6 +17,7 @@ export {
   tipoProgramaBadgeColors,
   tipoProgramaColors,
   tipoProgramaLabels,
+  tipoProgramaTextBadgeColors,
   tipoProgramaTextLabels,
 } from './program-types';
 

--- a/src/lib/config/program-types.ts
+++ b/src/lib/config/program-types.ts
@@ -78,3 +78,10 @@ export const tipoProgramaBadgeColors: Record<number, string> = {
   3: 'bg-diplomado-light text-diplomado',
   4: 'bg-curso-light text-curso',
 };
+
+export const tipoProgramaTextBadgeColors: Record<string, string> = {
+  maestria: 'bg-maestria-light text-maestria',
+  doctorado: 'bg-doctorado-light text-doctorado',
+  diplomado: 'bg-diplomado-light text-diplomado',
+  curso: 'bg-curso-light text-curso',
+};

--- a/src/pages/admision/index.astro
+++ b/src/pages/admision/index.astro
@@ -36,7 +36,7 @@ import { AdmisionContent } from '../../features/admision';
             </h1>
             
             <p class="text-xl text-gray-300 mb-8 max-w-2xl">
-              Inicia tu camino hacia la excelencia académica. Forma parte de la Escuela de Posgrado más prestigiosa de la región sur del Perú.
+              Inicia tu camino hacia la excelencia académica. Forma parte de la Escuela de Posgrado de la UNAP y fortalece tu perfil profesional desde Iquitos, en el corazón de la Amazonía peruana.
             </p>
             
             <div class="flex flex-wrap gap-4 mb-8">


### PR DESCRIPTION
## Summary
- replace the broken CTA links in the final admission banner with real destinations for online inquiry and advisor contact
- correct the admission page copy so it references Iquitos and the Amazonian context instead of the incorrect southern Peru wording
- align the admission program badges with the string-based program type config already used elsewhere in the UI

## Validation
- confirmed there are no remaining `href="#"` CTAs in the admission page
- confirmed the incorrect `Puno` and `sur del Perú` copy was removed
- `pnpm build` completes route generation successfully; the only remaining failure is the known Windows `@astrojs/vercel` symlink issue during final packaging