### PR TITLE
fix: el logo principal del Navbar hace zoom al hacer hover (#246)

### DIFF
--- a/src/features/navigation/components/Navbar.astro
+++ b/src/features/navigation/components/Navbar.astro
@@ -97,13 +97,13 @@ const secondaryNavItems: DropdownItem[] = [
     <div class="container-main">
       <div class="flex items-center justify-between h-16">
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-3 group">
+        <a href="/" class="flex items-center gap-3">
           <img
             src="/images/logo/logo-epg.webp"
             alt="Logo EPG UNAP"
             width="160"
             height="48"
-            class="h-10 sm:h-12 w-auto object-contain transition-transform group-hover:scale-105"
+            class="h-10 sm:h-12 w-auto object-contain"
             loading="eager"
           />
         </a>


### PR DESCRIPTION
Resuelve el issue #246 eliminando las clases `transition-transform group-hover:scale-105` del logo de EPG y retirando la clase `group` del enlace para que la imagen se mantenga completamente estática al hacer hover.

Closes #246