### PR TITLE
feat: enlazar convocatoria externa en el botón principal de admisión del Hero (#248)

### DIFF
--- a/src/features/home/components/Hero.astro
+++ b/src/features/home/components/Hero.astro
@@ -48,7 +48,9 @@ import { ArrowRight } from 'lucide-react';
       <!-- CTA Buttons -->
       <div class="flex flex-wrap gap-4 mb-10">
         <a
-          href="/admision"
+          href="https://admision.postgradounap.edu.pe/convocatorias/a0795f45-9d0e-42a5-ab2c-b13be87a993c"
+          target="_blank"
+          rel="noopener noreferrer"
           class="inline-flex items-center gap-2 bg-epg-gold hover:bg-epg-gold-dark text-epg-navy px-8 py-3 rounded-lg text-base font-bold shadow-lg shadow-epg-gold/25 transition-all duration-300 hover:shadow-xl hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-epg-gold focus-visible:ring-offset-2 focus-visible:ring-offset-epg-navy"
         >
           Postula ahora


### PR DESCRIPTION
Resuelve el issue #248 actualizando el enlace del botón 'Postula ahora' en la sección principal del sitio (Hero) para que redirija a la página oficial de convocatorias externas de la institución en una nueva pestaña.

Closes #248