### PR TITLE
feat(data): Implement seeder for 'sustentaciones' collection

### DIFF
--- a/scripts/seeder/index.ts
+++ b/scripts/seeder/index.ts
@@ -1,6 +1,7 @@
 import { seedDocentes } from './docentes';
 import { seedNoticias } from './noticias';
 import { seedAutoridades } from './autoridades';
+import { seedSustentaciones } from './sustentaciones';
 
 async function runSeeders() {
   console.log('🌱 Iniciando generación de datos (Seeders)...');
@@ -9,6 +10,7 @@ async function runSeeders() {
     await seedDocentes(30);
     await seedNoticias(25);
     await seedAutoridades();
+    await seedSustentaciones(15);
     
     console.log('✅ Todos los seeders se ejecutaron correctamente.');
   } catch (error) {

--- a/scripts/seeder/sustentaciones.ts
+++ b/scripts/seeder/sustentaciones.ts
@@ -1,0 +1,62 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fakerES_MX as faker } from '@faker-js/faker';
+
+const SUSTENTACIONES_DIR = path.join(process.cwd(), 'src/content/sustentaciones');
+
+export async function seedSustentaciones(count = 15) {
+  // We use a fixed seed here temporarily so it doesn't cause noise if re-run 
+  // until we globally fix faker randomness (Issue #260)
+  faker.seed(4242);
+  
+  await fs.mkdir(SUSTENTACIONES_DIR, { recursive: true });
+
+  // Clean directory first
+  const files = await fs.readdir(SUSTENTACIONES_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(SUSTENTACIONES_DIR, file));
+    }
+  }
+
+  const programas = [
+    'Maestría en Gestión Pública',
+    'Maestría en Salud Pública',
+    'Maestría en Ciencias Ambientales',
+    'Doctorado en Educación',
+    'Doctorado en Administración'
+  ];
+
+  const tipos = ['tesis', 'proyecto', 'trabajo_investigacion'];
+
+  for (let i = 0; i < count; i++) {
+    const slug = faker.string.uuid();
+    
+    // Generate an hour like 10:00 AM
+    const hora = faker.date.future().toLocaleTimeString('es-PE', { hour: '2-digit', minute: '2-digit' });
+
+    const sustentacion = {
+      id: `sus-${slug}`,
+      tesista: `${faker.person.firstName()} ${faker.person.lastName()}`,
+      titulo: faker.lorem.sentence({ min: 5, max: 10 }),
+      programa: faker.helpers.arrayElement(programas),
+      fecha: faker.date.future().toISOString().split('T')[0],
+      hora: hora,
+      lugar: faker.helpers.arrayElement(['Auditorio Principal', 'Aula Virtual 1', 'Aula Virtual 2', 'Sala de Grados']),
+      jurados: [
+        `${faker.person.firstName()} ${faker.person.lastName()}`,
+        `${faker.person.firstName()} ${faker.person.lastName()}`,
+        `${faker.person.firstName()} ${faker.person.lastName()}`
+      ],
+      asesor: `${faker.person.firstName()} ${faker.person.lastName()}`,
+      tipo: faker.helpers.arrayElement(tipos),
+    };
+
+    await fs.writeFile(
+      path.join(SUSTENTACIONES_DIR, `${slug}.json`),
+      JSON.stringify(sustentacion, null, 2)
+    );
+  }
+  
+  console.log(`✅ ${count} sustentaciones generadas en src/content/sustentaciones/`);
+}

--- a/src/content/sustentaciones/375a5607-7147-4ccf-85ce-37012e640607.json
+++ b/src/content/sustentaciones/375a5607-7147-4ccf-85ce-37012e640607.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-375a5607-7147-4ccf-85ce-37012e640607",
+  "tesista": "Marilu Escalante Bonilla",
+  "titulo": "Gendarmería Genciana Gemoterapia Incorporar Descerco Descerrajar Fidelísimo Cencellada Fice Generación.",
+  "programa": "Maestría en Ciencias Ambientales",
+  "fecha": "2026-12-19",
+  "hora": "00:45",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Jacobo Xana Pabón",
+    "Diana Olivera Mejía",
+    "Ángela Delacrúz Quintero"
+  ],
+  "asesor": "Rodrigo Castillo Olivas",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/3ae6de97-4367-4208-bb59-d568ba28e7d9.json
+++ b/src/content/sustentaciones/3ae6de97-4367-4208-bb59-d568ba28e7d9.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-3ae6de97-4367-4208-bb59-d568ba28e7d9",
+  "tesista": "María Fernanda Arenas Montemayor",
+  "titulo": "Cencerrear Gendarmería Batallador Batallar Generalato.",
+  "programa": "Doctorado en Educación",
+  "fecha": "2026-07-22",
+  "hora": "16:22",
+  "lugar": "Sala de Grados",
+  "jurados": [
+    "Kimberly Granados Agosto",
+    "Miguel Ángel Valle Cornejo",
+    "Armando Zepeda Villagómez"
+  ],
+  "asesor": "Ivan Almonte Carreón",
+  "tipo": "tesis"
+}

--- a/src/content/sustentaciones/5fe4ca85-b892-4720-afaa-c95471da0d3e.json
+++ b/src/content/sustentaciones/5fe4ca85-b892-4720-afaa-c95471da0d3e.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-5fe4ca85-b892-4720-afaa-c95471da0d3e",
+  "tesista": "Matías Galván Pabón",
+  "titulo": "Ficha Incorrección Descerrajar Generalidad Abadejo Incorporalmente Gemonias Incorregibilidad Deschuponar Increpar.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2027-03-03",
+  "hora": "01:26",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Caridad Mojica Mendoza",
+    "Lourdes Bétancourt Miranda",
+    "Ariadna Rocha Esquivel"
+  ],
+  "asesor": "Julio Águilar Salazar",
+  "tipo": "tesis"
+}

--- a/src/content/sustentaciones/8aa9fce1-1592-4a8e-aa29-fbae2d331edc.json
+++ b/src/content/sustentaciones/8aa9fce1-1592-4a8e-aa29-fbae2d331edc.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-8aa9fce1-1592-4a8e-aa29-fbae2d331edc",
+  "tesista": "Juan Pablo Delapaz Cisneros",
+  "titulo": "Generador Abacora Engarronar Gemoterapia Batalloso Abaldonadamente.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2026-08-09",
+  "hora": "02:02",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Hernán Delarosa Chavarría",
+    "Regina Suárez Valladares",
+    "Alondra Romina Pedroza Guzmán"
+  ],
+  "asesor": "David Moreno Flórez",
+  "tipo": "proyecto"
+}

--- a/src/content/sustentaciones/8e848e19-ee56-4375-a569-f5952bce62bd.json
+++ b/src/content/sustentaciones/8e848e19-ee56-4375-a569-f5952bce62bd.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-8e848e19-ee56-4375-a569-f5952bce62bd",
+  "tesista": "Julio Adame de Cervántez",
+  "titulo": "Descerrar Generalidad Engarzadura Batatazo Descercar Abacial Fice Cendalí Fidalgo.",
+  "programa": "Doctorado en Educación",
+  "fecha": "2026-08-17",
+  "hora": "13:37",
+  "lugar": "Sala de Grados",
+  "jurados": [
+    "Martín Muro Peres",
+    "Rosa Casillas de Duran",
+    "Tadeo Fernández Quinta"
+  ],
+  "asesor": "Reina Valverde Mercado",
+  "tipo": "proyecto"
+}

--- a/src/content/sustentaciones/98bc8c7d-a420-4244-845f-889db5e18020.json
+++ b/src/content/sustentaciones/98bc8c7d-a420-4244-845f-889db5e18020.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-98bc8c7d-a420-4244-845f-889db5e18020",
+  "tesista": "María Fernanda Yebra Raya",
+  "titulo": "General Fidelísimo Abajo Descervigamiento Incorporación.",
+  "programa": "Doctorado en Educación",
+  "fecha": "2027-03-02",
+  "hora": "01:36",
+  "lugar": "Aula Virtual 1",
+  "jurados": [
+    "José María Crespo Menéndez",
+    "Carlos Mateo Espino",
+    "Lola Carrasco Vanegas"
+  ],
+  "asesor": "Santiago Galarza Linares",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/9f96078e-058f-4dd9-9046-75fcf785d223.json
+++ b/src/content/sustentaciones/9f96078e-058f-4dd9-9046-75fcf785d223.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-9f96078e-058f-4dd9-9046-75fcf785d223",
+  "tesista": "Cristobal Valverde Fonseca",
+  "titulo": "Cendra Fichar Gemíparo Engarrar Deschavetarse Fideicomiso General Engarrafar Incorruptible.",
+  "programa": "Maestría en Salud Pública",
+  "fecha": "2027-02-07",
+  "hora": "19:48",
+  "lugar": "Auditorio Principal",
+  "jurados": [
+    "Elvira Rodríquez Caldera",
+    "Alberto Serrano Domínguez",
+    "Claudio Cabrera Palomino"
+  ],
+  "asesor": "Natalia Velásquez Marrero",
+  "tipo": "proyecto"
+}

--- a/src/content/sustentaciones/affeaeab-d688-4d36-8bd9-1651505bd580.json
+++ b/src/content/sustentaciones/affeaeab-d688-4d36-8bd9-1651505bd580.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-affeaeab-d688-4d36-8bd9-1651505bd580",
+  "tesista": "Julio Padilla Yami",
+  "titulo": "General Descentrar Descercado Batanear Descentralización Abad Abalada Cendra Incorregible.",
+  "programa": "Maestría en Salud Pública",
+  "fecha": "2026-12-18",
+  "hora": "05:18",
+  "lugar": "Auditorio Principal",
+  "jurados": [
+    "Jerónimo Macías Quinta",
+    "Esperanza Ochoa de Villagómez",
+    "Luis Gabino Valdés Piña"
+  ],
+  "asesor": "Abigail Ramos Cabán",
+  "tipo": "tesis"
+}

--- a/src/content/sustentaciones/b077f45f-117c-4c31-9ef6-f42af9ae4ee6.json
+++ b/src/content/sustentaciones/b077f45f-117c-4c31-9ef6-f42af9ae4ee6.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-b077f45f-117c-4c31-9ef6-f42af9ae4ee6",
+  "tesista": "Jose Daniel Manzanares Delgado",
+  "titulo": "Cencerrón Fichar Batavia Descerrumarse Batacazo Engastadura.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2026-04-18",
+  "hora": "21:21",
+  "lugar": "Auditorio Principal",
+  "jurados": [
+    "Diego Aguirre Yunta",
+    "Soledad Ferrer Zambrana",
+    "Andrés Medrano de Quezada"
+  ],
+  "asesor": "Alondra Romina Vargas Orta",
+  "tipo": "proyecto"
+}

--- a/src/content/sustentaciones/b9e2f95b-2eed-480f-aea3-713099858172.json
+++ b/src/content/sustentaciones/b9e2f95b-2eed-480f-aea3-713099858172.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-b9e2f95b-2eed-480f-aea3-713099858172",
+  "tesista": "Araceli Peres Loya",
+  "titulo": "Fido Gemólogo Incrasar Cendalí Batallola Incorporalmente Fidecomiso Incrédulo Descentralización Cendrar.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2026-10-06",
+  "hora": "15:50",
+  "lugar": "Auditorio Principal",
+  "jurados": [
+    "José Eduardo Apodaca Gutiérrez",
+    "Luisa Leal Aragón",
+    "Marilu Muñiz Meléndez"
+  ],
+  "asesor": "Carlos Quintero de Cepeda",
+  "tipo": "proyecto"
+}

--- a/src/content/sustentaciones/cf31027b-2832-470b-8433-947779746bf9.json
+++ b/src/content/sustentaciones/cf31027b-2832-470b-8433-947779746bf9.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-cf31027b-2832-470b-8433-947779746bf9",
+  "tesista": "Guadalupe Zepeda de Bétancourt",
+  "titulo": "Descerebrar Cenal Geminar Descimbramiento Incruento Engarce Engargantar Descharchar Gendarme Batán.",
+  "programa": "Doctorado en Educación",
+  "fecha": "2027-01-10",
+  "hora": "03:26",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Daniel Terrazas de Vargas",
+    "Teodoro Gaytán Zepeda",
+    "Damián Yunta Delafuente"
+  ],
+  "asesor": "Luis Fernando Godoy de Ayala",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/d6fbddb2-a5a0-4d08-b521-1893d7051e61.json
+++ b/src/content/sustentaciones/d6fbddb2-a5a0-4d08-b521-1893d7051e61.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-d6fbddb2-a5a0-4d08-b521-1893d7051e61",
+  "tesista": "Luis Miguel Loya Kranz sans",
+  "titulo": "Descentrado Basurero Engargante Descimbrar Gencianeo Engaste Engargantar Fice Ficticio Engarberar.",
+  "programa": "Maestría en Gestión Pública",
+  "fecha": "2026-05-06",
+  "hora": "19:32",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Ana Victoria Dávila Anaya",
+    "Juan Carlos Cadena Olivares",
+    "Dolores Ontiveros Zelaya"
+  ],
+  "asesor": "Gerardo Sanches Castañeda",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/d895975a-4b6a-4f82-b391-d17674d95eb3.json
+++ b/src/content/sustentaciones/d895975a-4b6a-4f82-b391-d17674d95eb3.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-d895975a-4b6a-4f82-b391-d17674d95eb3",
+  "tesista": "Jennifer de Anda Huerta",
+  "titulo": "Ficoideo Descerrajado Géminis Incorrecto Cendradilla Cencerrón Generala Abada Genealógico Abalanzar.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2026-11-14",
+  "hora": "00:07",
+  "lugar": "Aula Virtual 2",
+  "jurados": [
+    "Benjamín Rolón Puente",
+    "Luis Ángel Rosario Badillo",
+    "Jaime Vera Villarreal"
+  ],
+  "asesor": "María Guadalupe Espinal de Navarrete",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/db0372cf-7bae-4e10-83e0-3cfd871f92a6.json
+++ b/src/content/sustentaciones/db0372cf-7bae-4e10-83e0-3cfd871f92a6.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-db0372cf-7bae-4e10-83e0-3cfd871f92a6",
+  "tesista": "Ángel Gabriel Urrutia Holguín",
+  "titulo": "Engarbullar Descercar Cencellada Incristalizable Bátavo.",
+  "programa": "Doctorado en Administración",
+  "fecha": "2027-02-28",
+  "hora": "08:56",
+  "lugar": "Sala de Grados",
+  "jurados": [
+    "Mayte Santiago de Xairo Belmonte",
+    "Olivia Nieto Valentín",
+    "Leonardo Tamez de Vera"
+  ],
+  "asesor": "Arturo Campos de Quintairos",
+  "tipo": "trabajo_investigacion"
+}

--- a/src/content/sustentaciones/fe3fd7b1-d9da-43e8-a14f-4b4690f4dee8.json
+++ b/src/content/sustentaciones/fe3fd7b1-d9da-43e8-a14f-4b4690f4dee8.json
@@ -1,0 +1,16 @@
+{
+  "id": "sus-fe3fd7b1-d9da-43e8-a14f-4b4690f4dee8",
+  "tesista": "Xochitl Mora Vaca",
+  "titulo": "Cenero Abalaustrado Abalanzar Cenata Bástulo Incredibilidad Incorregiblemente Descerrar.",
+  "programa": "Maestría en Gestión Pública",
+  "fecha": "2026-05-21",
+  "hora": "00:00",
+  "lugar": "Sala de Grados",
+  "jurados": [
+    "Melissa Cedillo de Tejeda",
+    "Salvador Cortez Serna",
+    "Jennifer Abeyta Luevano"
+  ],
+  "asesor": "Santiago Rosado Osorio",
+  "tipo": "proyecto"
+}


### PR DESCRIPTION
Resolves #253

## Summary
- Implemented a new seeder script in `scripts/seeder/sustentaciones.ts` using `@faker-js/faker`.
- **Note:** Applied a temporary `faker.seed()` specifically for this script so we don't introduce Git conflicts, aligning with best practices while we prepare to tackle the global randomness issue (#260).
- Updated `scripts/seeder/index.ts` to call the new seeder function.
- Populated `src/content/sustentaciones/` with 15 mock records, eliminating the Astro `[glob-loader]` empty collection warning during build.