### PR TITLE
refactor: migrate estudiantes data to content collections

### DIFF
--- a/scripts/seeder/estudiantes.ts
+++ b/scripts/seeder/estudiantes.ts
@@ -1,0 +1,506 @@
+import { faker } from '@faker-js/faker';
+import fs from 'fs/promises';
+import path from 'path';
+
+const accesosRapidos = [
+  {
+    id: 'sigae',
+    nombre: 'SIGAE',
+    descripcion: 'Sistema Integrado de Gestión Académica',
+    icono: 'clipboard',
+    href: 'https://sigae.unapiquitos.edu.pe',
+    color: 'bg-epg-navy'
+  },
+  {
+    id: 'aula-virtual',
+    nombre: 'Aula Virtual',
+    descripcion: 'Plataforma de aprendizaje en línea',
+    icono: 'monitor',
+    href: 'https://aulavirtual.unapiquitos.edu.pe',
+    color: 'bg-epg-navy'
+  },
+  {
+    id: 'biblioteca',
+    nombre: 'Biblioteca Virtual',
+    descripcion: 'Acceso a recursos bibliográficos',
+    icono: 'book-open',
+    href: 'https://biblioteca.unapiquitos.edu.pe',
+    color: 'bg-epg-navy'
+  },
+  {
+    id: 'correo',
+    nombre: 'Correo Institucional',
+    descripcion: 'Email @unapiquitos.edu.pe',
+    icono: 'mail',
+    href: 'https://mail.google.com',
+    color: 'bg-epg-navy'
+  }
+];
+
+const tramitesEstudiantiles = [
+  {
+    id: 'matricula',
+    nombre: 'Matrícula',
+    descripcion: 'Proceso de inscripción a las asignaturas del semestre académico.',
+    icono: 'clipboard-check',
+    color: 'bg-blue-100',
+    iconColor: 'text-blue-600',
+    href: '/estudiantes/matricula',
+    requisitos: [
+      'Estar al día en pagos',
+      'No tener deudas con biblioteca',
+      'Haber aprobado requisitos previos de las asignaturas'
+    ],
+    pasos: [
+      'Ingresar al SIGAE con usuario y contraseña',
+      'Seleccionar "Matrícula" en el menú principal',
+      'Elegir las asignaturas disponibles',
+      'Confirmar matrícula y generar boleta de pago',
+      'Realizar el pago en ventanilla o banca electrónica'
+    ],
+    documentos: [
+      'Constancia de no adeudo (si aplica)',
+      'Ficha de matrícula firmada'
+    ],
+    duracion: '1-2 días hábiles'
+  },
+  {
+    id: 'tramite-grado',
+    nombre: 'Trámite de Grado',
+    descripcion: 'Proceso para obtener el grado académico de Magíster o Doctor.',
+    icono: 'award',
+    color: 'bg-amber-100',
+    iconColor: 'text-amber-600',
+    href: '/estudiantes/tramite-grado',
+    requisitos: [
+      'Haber aprobado todas las asignaturas del plan de estudios',
+      'Tesis aprobada y sustentada',
+      'Constancia de no adeudo de biblioteca',
+      'Estar al día en pagos administrativos'
+    ],
+    pasos: [
+      'Solicitar expedito en la Unidad de Postgrado',
+      'Presentar documentación completa en mesa de partes',
+      'Esperar revisión y aprobación del expediente',
+      'Participar en ceremonia de graduación o recojo individual'
+    ],
+    documentos: [
+      'Solicitud dirigida al Director de la EPG',
+      'Acta de sustentación de tesis',
+      'Tesis empastada (3 ejemplares)',
+      'CD con tesis en formato digital',
+      'Constancia de no adeudo',
+      'Fotos tamaño pasaporte (6 unidades)',
+      'Copia de DNI',
+      'Recibo de pago por derechos de grado'
+    ],
+    costo: 'S/ 500.00',
+    duracion: '30-45 días hábiles'
+  },
+  {
+    id: 'sustentaciones',
+    nombre: 'Sustentaciones',
+    descripcion: 'Cronograma y requisitos para la defensa de tesis.',
+    icono: 'users',
+    color: 'bg-green-100',
+    iconColor: 'text-green-600',
+    href: '/estudiantes/sustentaciones',
+    requisitos: [
+      'Proyecto de tesis aprobado',
+      'Informe de asesor con visto bueno',
+      'Revisión de similitud (Turnitin) menor al 25%',
+      'Constancia de no adeudo'
+    ],
+    pasos: [
+      'Presentar borrador de tesis al asesor',
+      'Obtener visto bueno del asesor',
+      'Presentar solicitud de designación de jurado',
+      'Esperar resolución de designación de jurado',
+      'Entregar tesis a jurados para revisión',
+      'Levantar observaciones (si las hubiera)',
+      'Programar fecha de sustentación',
+      'Sustentar tesis ante el jurado'
+    ],
+    documentos: [
+      'Tesis en formato PDF (4 ejemplares)',
+      'Informe del asesor',
+      'Constancia de Turnitin',
+      'Solicitud de sustentación'
+    ],
+    duracion: '15-30 días hábiles'
+  },
+  {
+    id: 'licencia-estudios',
+    nombre: 'Licencia de Estudios',
+    descripcion: 'Solicitud de suspensión temporal de estudios por motivos justificados.',
+    icono: 'pause-circle',
+    color: 'bg-purple-100',
+    iconColor: 'text-purple-600',
+    href: '/estudiantes/licencia-estudios',
+    requisitos: [
+      'Estar matriculado en el semestre actual',
+      'Tener motivo justificado (salud, trabajo, viaje, etc.)',
+      'No tener deudas pendientes'
+    ],
+    pasos: [
+      'Presentar solicitud en mesa de partes',
+      'Adjuntar documentos sustentatorios',
+      'Esperar resolución de la Dirección',
+      'Recibir resolución de licencia aprobada'
+    ],
+    documentos: [
+      'Solicitud dirigida al Director',
+      'Documentos que justifiquen la licencia',
+      'Constancia de no adeudo'
+    ],
+    duracion: '5-10 días hábiles'
+  },
+  {
+    id: 'cambio-programa',
+    nombre: 'Cambio de Programa',
+    descripcion: 'Procedimiento para trasladarse a otro programa de la EPG.',
+    icono: 'shuffle',
+    color: 'bg-indigo-100',
+    iconColor: 'text-indigo-600',
+    href: '/estudiantes/cambio-programa',
+    requisitos: [
+      'Haber cursado al menos un semestre',
+      'Promedio mínimo de 14',
+      'Vacante disponible en el programa destino',
+      'Estar al día en pagos'
+    ],
+    pasos: [
+      'Solicitar informe de estudios y notas',
+      'Presentar solicitud de cambio de programa',
+      'Esperar evaluación del Comité Académico',
+      'Recibir resolución de aprobación',
+      'Realizar convalidación de asignaturas'
+    ],
+    documentos: [
+      'Solicitud dirigida al Director',
+      'Record de notas',
+      'Sílabos de asignaturas aprobadas',
+      'Carta de motivación'
+    ],
+    costo: 'S/ 150.00',
+    duracion: '15-20 días hábiles'
+  },
+  {
+    id: 'certificados',
+    nombre: 'Certificados y Constancias',
+    descripcion: 'Solicitud de documentos académicos oficiales.',
+    icono: 'file-text',
+    color: 'bg-red-100',
+    iconColor: 'text-red-600',
+    href: '/estudiantes/certificados',
+    requisitos: [
+      'Ser estudiante o egresado de la EPG',
+      'Estar al día en pagos'
+    ],
+    pasos: [
+      'Realizar pago por derecho de certificado',
+      'Presentar solicitud con recibo de pago',
+      'Esperar procesamiento del documento',
+      'Recoger documento en mesa de partes'
+    ],
+    documentos: [
+      'Solicitud simple',
+      'Recibo de pago',
+      'Copia de DNI'
+    ],
+    costo: 'S/ 30.00 - S/ 80.00',
+    duracion: '3-5 días hábiles'
+  }
+];
+
+const documentosDescargables = [
+  {
+    id: 'reglamento-general',
+    nombre: 'Reglamento General de la EPG',
+    descripcion: 'Normativa general que rige el funcionamiento de la Escuela de Postgrado',
+    tipo: 'pdf',
+    categoria: 'reglamento',
+    url: '/documentos/reglamento-general-epg.pdf',
+    fechaActualizacion: '2024-03-15'
+  },
+  {
+    id: 'reglamento-grados',
+    nombre: 'Reglamento de Grados y Títulos',
+    descripcion: 'Procedimientos para la obtención de grados académicos',
+    tipo: 'pdf',
+    categoria: 'reglamento',
+    url: '/documentos/reglamento-grados-titulos.pdf',
+    fechaActualizacion: '2024-02-20'
+  },
+  {
+    id: 'formato-proyecto-tesis',
+    nombre: 'Formato de Proyecto de Tesis',
+    descripcion: 'Plantilla oficial para la presentación del proyecto de investigación',
+    tipo: 'docx',
+    categoria: 'formato',
+    url: '/documentos/formato-proyecto-tesis.docx',
+    fechaActualizacion: '2024-01-10'
+  },
+  {
+    id: 'guia-elaboracion-tesis',
+    nombre: 'Guía de Elaboración de Tesis',
+    descripcion: 'Manual con lineamientos para la redacción de tesis',
+    tipo: 'pdf',
+    categoria: 'guia',
+    url: '/documentos/guia-elaboracion-tesis.pdf',
+    fechaActualizacion: '2024-03-01'
+  },
+  {
+    id: 'formato-informe-asesor',
+    nombre: 'Formato de Informe de Asesor',
+    descripcion: 'Plantilla para el informe de avance del asesor de tesis',
+    tipo: 'docx',
+    categoria: 'formato',
+    url: '/documentos/formato-informe-asesor.docx',
+    fechaActualizacion: '2024-02-15'
+  },
+  {
+    id: 'solicitud-general',
+    nombre: 'Formato de Solicitud General (FUT)',
+    descripcion: 'Formulario único de trámite para diversas solicitudes',
+    tipo: 'docx',
+    categoria: 'formato',
+    url: '/documentos/fut-solicitud-general.docx',
+    fechaActualizacion: '2024-01-05'
+  },
+  {
+    id: 'manual-apa7',
+    nombre: 'Manual de Estilo APA 7ma Edición',
+    descripcion: 'Guía de citación y referencias bibliográficas',
+    tipo: 'pdf',
+    categoria: 'manual',
+    url: '/documentos/manual-apa7.pdf',
+    fechaActualizacion: '2023-12-01'
+  },
+  {
+    id: 'formato-constancia-no-adeudo',
+    nombre: 'Solicitud de Constancia de No Adeudo',
+    descripcion: 'Formato para solicitar constancia de no adeudo',
+    tipo: 'docx',
+    categoria: 'formato',
+    url: '/documentos/solicitud-constancia-no-adeudo.docx',
+    fechaActualizacion: '2024-01-20'
+  }
+];
+
+const calendarioAcademico = [
+  {
+    id: 'matricula-2026-1',
+    titulo: 'Matrícula Regular 2026-I',
+    descripcion: 'Periodo de matrícula para el semestre 2026-I',
+    fechaInicio: '2026-05-18',
+    fechaFin: '2026-05-29',
+    tipo: 'matricula',
+    importante: true
+  },
+  {
+    id: 'inicio-clases-2026-1',
+    titulo: 'Inicio de Clases 2026-I',
+    descripcion: 'Inicio del semestre académico 2026-I',
+    fechaInicio: '2026-06-01',
+    tipo: 'evento',
+    importante: true
+  },
+  {
+    id: 'examen-parcial-2026-1',
+    titulo: 'Exámenes Parciales 2026-I',
+    descripcion: 'Semana de evaluaciones parciales',
+    fechaInicio: '2026-07-20',
+    fechaFin: '2026-07-25',
+    tipo: 'examen',
+    importante: true
+  },
+  {
+    id: 'pago-cuota2-2026-1',
+    titulo: 'Fecha límite pago 2da cuota',
+    descripcion: 'Último día para pagar la segunda cuota del semestre',
+    fechaInicio: '2026-07-10',
+    tipo: 'pago',
+    importante: true
+  },
+  {
+    id: 'examen-final-2026-1',
+    titulo: 'Exámenes Finales 2026-I',
+    descripcion: 'Semana de evaluaciones finales',
+    fechaInicio: '2026-09-28',
+    fechaFin: '2026-10-03',
+    tipo: 'examen',
+    importante: true
+  },
+  {
+    id: 'sustentaciones-septiembre',
+    titulo: 'Sustentaciones de Tesis - Septiembre',
+    descripcion: 'Periodo programado para sustentaciones de tesis',
+    fechaInicio: '2026-09-14',
+    fechaFin: '2026-09-25',
+    tipo: 'sustentacion',
+    importante: false
+  },
+  {
+    id: 'vacaciones-medio-ano',
+    titulo: 'Vacaciones de Medio Año',
+    descripcion: 'Periodo de vacaciones entre semestres',
+    fechaInicio: '2026-08-10',
+    fechaFin: '2026-08-23',
+    tipo: 'vacaciones',
+    importante: false
+  },
+  {
+    id: 'matricula-2026-2',
+    titulo: 'Matrícula Regular 2026-II',
+    descripcion: 'Periodo de matrícula para el semestre 2026-II',
+    fechaInicio: '2026-10-19',
+    fechaFin: '2026-10-30',
+    tipo: 'matricula',
+    importante: true
+  }
+];
+
+const recursosAcademicos = [
+  {
+    id: 'repositorio-tesis',
+    nombre: 'Repositorio de Tesis',
+    descripcion: 'Acceso a tesis de maestría y doctorado',
+    icono: 'database',
+    href: 'https://repositorio.unapiquitos.edu.pe',
+    externo: true
+  },
+  {
+    id: 'bases-datos',
+    nombre: 'Bases de Datos Científicas',
+    descripcion: 'Scopus, Web of Science, Scielo y más',
+    icono: 'search',
+    href: '/servicios/bases-datos',
+    externo: false
+  },
+  {
+    id: 'turnitin',
+    nombre: 'Turnitin',
+    descripcion: 'Sistema de detección de similitud',
+    icono: 'shield-check',
+    href: 'https://www.turnitin.com',
+    externo: true
+  },
+  {
+    id: 'mendeley',
+    nombre: 'Mendeley',
+    descripcion: 'Gestor de referencias bibliográficas',
+    icono: 'bookmark',
+    href: 'https://www.mendeley.com',
+    externo: true
+  },
+  {
+    id: 'google-scholar',
+    nombre: 'Google Scholar',
+    descripcion: 'Buscador de literatura académica',
+    icono: 'graduation-cap',
+    href: 'https://scholar.google.com',
+    externo: true
+  },
+  {
+    id: 'orcid',
+    nombre: 'ORCID',
+    descripcion: 'Identificador de investigador',
+    icono: 'user-check',
+    href: 'https://orcid.org',
+    externo: true
+  }
+];
+
+const preguntasFrecuentes = [
+  {
+    id: 'faq-1',
+    pregunta: '¿Cuál es el plazo máximo para terminar la maestría?',
+    respuesta: 'El plazo máximo para culminar los estudios de maestría es de 4 años contados desde la fecha de ingreso. En casos excepcionales, se puede solicitar una ampliación de plazo presentando una solicitud debidamente justificada.',
+    categoria: 'general'
+  },
+  {
+    id: 'faq-2',
+    pregunta: '¿Cómo puedo solicitar una constancia de estudios?',
+    respuesta: 'Debe presentar una solicitud (FUT) en mesa de partes adjuntando el recibo de pago correspondiente (S/ 30.00). El documento estará listo en 3 a 5 días hábiles.',
+    categoria: 'tramites'
+  },
+  {
+    id: 'faq-3',
+    pregunta: '¿Cuántas veces puedo sustentar mi tesis si desapruebo?',
+    respuesta: 'El estudiante tiene derecho a dos (2) oportunidades adicionales para sustentar su tesis en caso de desaprobación. Cada nueva sustentación requiere un pago adicional por derecho de sustentación.',
+    categoria: 'tesis'
+  },
+  {
+    id: 'faq-4',
+    pregunta: '¿Puedo realizar pagos fraccionados?',
+    respuesta: 'Sí, la pensión de estudios puede pagarse en cuotas mensuales según el cronograma establecido por la EPG. El incumplimiento de pagos puede generar intereses y restricciones en el acceso a servicios académicos.',
+    categoria: 'pagos'
+  },
+  {
+    id: 'faq-5',
+    pregunta: '¿Qué porcentaje de similitud acepta Turnitin?',
+    respuesta: 'El porcentaje máximo de similitud permitido es del 25%. Si la tesis supera este porcentaje, deberá realizar las correcciones necesarias antes de poder sustentar.',
+    categoria: 'tesis'
+  },
+  {
+    id: 'faq-6',
+    pregunta: '¿Cómo solicito cambio de asesor de tesis?',
+    respuesta: 'Debe presentar una solicitud (FUT) indicando los motivos del cambio, adjuntando una carta de aceptación del nuevo asesor propuesto. La solicitud será evaluada por el Comité de Investigación.',
+    categoria: 'tesis'
+  },
+  {
+    id: 'faq-7',
+    pregunta: '¿Puedo matricularme en asignaturas de otro programa?',
+    respuesta: 'Sí, puede llevar asignaturas electivas de otros programas siempre que existan vacantes disponibles y cuente con la autorización del coordinador de su programa.',
+    categoria: 'matricula'
+  },
+  {
+    id: 'faq-8',
+    pregunta: '¿Qué pasa si no me matriculo en un semestre?',
+    respuesta: 'Si no se matricula en un semestre sin haber solicitado licencia, será considerado como abandono de estudios. Para reingresar, deberá solicitar reincorporación y regularizar su situación académica.',
+    categoria: 'matricula'
+  }
+];
+
+export async function seedEstudiantes() {
+  faker.seed(456); // Determinism
+  
+  const writeCollection = async (dirName: string, data: any[]) => {
+    const contentDir = path.join(process.cwd(), 'src/content', dirName);
+    
+    await fs.mkdir(contentDir, { recursive: true });
+    
+    // Clear existing
+    const files = await fs.readdir(contentDir);
+    for (const file of files) {
+      if (file.endsWith('.json')) {
+        await fs.unlink(path.join(contentDir, file));
+      }
+    }
+    
+    for (const item of data) {
+      const fileName = `${item.id}.json`;
+      const filePath = path.join(contentDir, fileName);
+      
+      await fs.writeFile(
+        filePath,
+        JSON.stringify(item, null, 2),
+        'utf-8'
+      );
+    }
+    
+    console.log(`✅ ${data.length} items generados en src/content/${dirName}`);
+  };
+
+  try {
+    await writeCollection('estudiantes_accesos', accesosRapidos);
+    await writeCollection('estudiantes_tramites', tramitesEstudiantiles);
+    await writeCollection('estudiantes_documentos', documentosDescargables);
+    await writeCollection('estudiantes_calendario', calendarioAcademico);
+    await writeCollection('estudiantes_recursos', recursosAcademicos);
+    await writeCollection('estudiantes_faq', preguntasFrecuentes);
+  } catch (error) {
+    console.error('Error seeding estudiantes:', error);
+  }
+}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -132,7 +132,91 @@ const serviciosCollection = defineCollection({
   }),
 });
 
+const estudiantesAccesosCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string(),
+    icono: z.string(),
+    href: z.string(),
+    color: z.string(),
+  }),
+});
+
+const estudiantesTramitesCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string(),
+    icono: z.string(),
+    color: z.string(),
+    iconColor: z.string(),
+    href: z.string(),
+    requisitos: z.array(z.string()),
+    pasos: z.array(z.string()),
+    documentos: z.array(z.string()),
+    costo: z.string().optional(),
+    duracion: z.string().optional(),
+  }),
+});
+
+const estudiantesDocumentosCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string(),
+    tipo: z.enum(['pdf', 'docx', 'xlsx']),
+    categoria: z.enum(['reglamento', 'formato', 'guia', 'manual']),
+    url: z.string(),
+    fechaActualizacion: z.string(),
+  }),
+});
+
+const estudiantesCalendarioCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    titulo: z.string(),
+    descripcion: z.string(),
+    fechaInicio: z.string(),
+    fechaFin: z.string().optional(),
+    tipo: z.enum(['matricula', 'examen', 'sustentacion', 'vacaciones', 'evento', 'pago']),
+    importante: z.boolean(),
+  }),
+});
+
+const estudiantesRecursosCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string(),
+    icono: z.string(),
+    href: z.string(),
+    externo: z.boolean(),
+  }),
+});
+
+const estudiantesFaqCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    pregunta: z.string(),
+    respuesta: z.string(),
+    categoria: z.enum(['matricula', 'tramites', 'tesis', 'pagos', 'general']),
+  }),
+});
+
 export const collections = {
+  estudiantes_accesos: estudiantesAccesosCollection,
+  estudiantes_tramites: estudiantesTramitesCollection,
+  estudiantes_documentos: estudiantesDocumentosCollection,
+  estudiantes_calendario: estudiantesCalendarioCollection,
+  estudiantes_recursos: estudiantesRecursosCollection,
+  estudiantes_faq: estudiantesFaqCollection,
   servicios: serviciosCollection,
   programas: programasCollection,
   noticias: noticiasCollection,

--- a/src/content/estudiantes_accesos/aula-virtual.json
+++ b/src/content/estudiantes_accesos/aula-virtual.json
@@ -1,0 +1,8 @@
+{
+  "id": "aula-virtual",
+  "nombre": "Aula Virtual",
+  "descripcion": "Plataforma de aprendizaje en línea",
+  "icono": "monitor",
+  "href": "https://aulavirtual.unapiquitos.edu.pe",
+  "color": "bg-epg-navy"
+}

--- a/src/content/estudiantes_accesos/biblioteca.json
+++ b/src/content/estudiantes_accesos/biblioteca.json
@@ -1,0 +1,8 @@
+{
+  "id": "biblioteca",
+  "nombre": "Biblioteca Virtual",
+  "descripcion": "Acceso a recursos bibliográficos",
+  "icono": "book-open",
+  "href": "https://biblioteca.unapiquitos.edu.pe",
+  "color": "bg-epg-navy"
+}

--- a/src/content/estudiantes_accesos/correo.json
+++ b/src/content/estudiantes_accesos/correo.json
@@ -1,0 +1,8 @@
+{
+  "id": "correo",
+  "nombre": "Correo Institucional",
+  "descripcion": "Email @unapiquitos.edu.pe",
+  "icono": "mail",
+  "href": "https://mail.google.com",
+  "color": "bg-epg-navy"
+}

--- a/src/content/estudiantes_accesos/sigae.json
+++ b/src/content/estudiantes_accesos/sigae.json
@@ -1,0 +1,8 @@
+{
+  "id": "sigae",
+  "nombre": "SIGAE",
+  "descripcion": "Sistema Integrado de Gestión Académica",
+  "icono": "clipboard",
+  "href": "https://sigae.unapiquitos.edu.pe",
+  "color": "bg-epg-navy"
+}

--- a/src/content/estudiantes_calendario/examen-final-2026-1.json
+++ b/src/content/estudiantes_calendario/examen-final-2026-1.json
@@ -1,0 +1,9 @@
+{
+  "id": "examen-final-2026-1",
+  "titulo": "Exámenes Finales 2026-I",
+  "descripcion": "Semana de evaluaciones finales",
+  "fechaInicio": "2026-09-28",
+  "fechaFin": "2026-10-03",
+  "tipo": "examen",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/examen-parcial-2026-1.json
+++ b/src/content/estudiantes_calendario/examen-parcial-2026-1.json
@@ -1,0 +1,9 @@
+{
+  "id": "examen-parcial-2026-1",
+  "titulo": "Exámenes Parciales 2026-I",
+  "descripcion": "Semana de evaluaciones parciales",
+  "fechaInicio": "2026-07-20",
+  "fechaFin": "2026-07-25",
+  "tipo": "examen",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/inicio-clases-2026-1.json
+++ b/src/content/estudiantes_calendario/inicio-clases-2026-1.json
@@ -1,0 +1,8 @@
+{
+  "id": "inicio-clases-2026-1",
+  "titulo": "Inicio de Clases 2026-I",
+  "descripcion": "Inicio del semestre académico 2026-I",
+  "fechaInicio": "2026-06-01",
+  "tipo": "evento",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/matricula-2026-1.json
+++ b/src/content/estudiantes_calendario/matricula-2026-1.json
@@ -1,0 +1,9 @@
+{
+  "id": "matricula-2026-1",
+  "titulo": "Matrícula Regular 2026-I",
+  "descripcion": "Periodo de matrícula para el semestre 2026-I",
+  "fechaInicio": "2026-05-18",
+  "fechaFin": "2026-05-29",
+  "tipo": "matricula",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/matricula-2026-2.json
+++ b/src/content/estudiantes_calendario/matricula-2026-2.json
@@ -1,0 +1,9 @@
+{
+  "id": "matricula-2026-2",
+  "titulo": "Matrícula Regular 2026-II",
+  "descripcion": "Periodo de matrícula para el semestre 2026-II",
+  "fechaInicio": "2026-10-19",
+  "fechaFin": "2026-10-30",
+  "tipo": "matricula",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/pago-cuota2-2026-1.json
+++ b/src/content/estudiantes_calendario/pago-cuota2-2026-1.json
@@ -1,0 +1,8 @@
+{
+  "id": "pago-cuota2-2026-1",
+  "titulo": "Fecha límite pago 2da cuota",
+  "descripcion": "Último día para pagar la segunda cuota del semestre",
+  "fechaInicio": "2026-07-10",
+  "tipo": "pago",
+  "importante": true
+}

--- a/src/content/estudiantes_calendario/sustentaciones-septiembre.json
+++ b/src/content/estudiantes_calendario/sustentaciones-septiembre.json
@@ -1,0 +1,9 @@
+{
+  "id": "sustentaciones-septiembre",
+  "titulo": "Sustentaciones de Tesis - Septiembre",
+  "descripcion": "Periodo programado para sustentaciones de tesis",
+  "fechaInicio": "2026-09-14",
+  "fechaFin": "2026-09-25",
+  "tipo": "sustentacion",
+  "importante": false
+}

--- a/src/content/estudiantes_calendario/vacaciones-medio-ano.json
+++ b/src/content/estudiantes_calendario/vacaciones-medio-ano.json
@@ -1,0 +1,9 @@
+{
+  "id": "vacaciones-medio-ano",
+  "titulo": "Vacaciones de Medio Año",
+  "descripcion": "Periodo de vacaciones entre semestres",
+  "fechaInicio": "2026-08-10",
+  "fechaFin": "2026-08-23",
+  "tipo": "vacaciones",
+  "importante": false
+}

--- a/src/content/estudiantes_documentos/formato-constancia-no-adeudo.json
+++ b/src/content/estudiantes_documentos/formato-constancia-no-adeudo.json
@@ -1,0 +1,9 @@
+{
+  "id": "formato-constancia-no-adeudo",
+  "nombre": "Solicitud de Constancia de No Adeudo",
+  "descripcion": "Formato para solicitar constancia de no adeudo",
+  "tipo": "docx",
+  "categoria": "formato",
+  "url": "/documentos/solicitud-constancia-no-adeudo.docx",
+  "fechaActualizacion": "2024-01-20"
+}

--- a/src/content/estudiantes_documentos/formato-informe-asesor.json
+++ b/src/content/estudiantes_documentos/formato-informe-asesor.json
@@ -1,0 +1,9 @@
+{
+  "id": "formato-informe-asesor",
+  "nombre": "Formato de Informe de Asesor",
+  "descripcion": "Plantilla para el informe de avance del asesor de tesis",
+  "tipo": "docx",
+  "categoria": "formato",
+  "url": "/documentos/formato-informe-asesor.docx",
+  "fechaActualizacion": "2024-02-15"
+}

--- a/src/content/estudiantes_documentos/formato-proyecto-tesis.json
+++ b/src/content/estudiantes_documentos/formato-proyecto-tesis.json
@@ -1,0 +1,9 @@
+{
+  "id": "formato-proyecto-tesis",
+  "nombre": "Formato de Proyecto de Tesis",
+  "descripcion": "Plantilla oficial para la presentación del proyecto de investigación",
+  "tipo": "docx",
+  "categoria": "formato",
+  "url": "/documentos/formato-proyecto-tesis.docx",
+  "fechaActualizacion": "2024-01-10"
+}

--- a/src/content/estudiantes_documentos/guia-elaboracion-tesis.json
+++ b/src/content/estudiantes_documentos/guia-elaboracion-tesis.json
@@ -1,0 +1,9 @@
+{
+  "id": "guia-elaboracion-tesis",
+  "nombre": "Guía de Elaboración de Tesis",
+  "descripcion": "Manual con lineamientos para la redacción de tesis",
+  "tipo": "pdf",
+  "categoria": "guia",
+  "url": "/documentos/guia-elaboracion-tesis.pdf",
+  "fechaActualizacion": "2024-03-01"
+}

--- a/src/content/estudiantes_documentos/manual-apa7.json
+++ b/src/content/estudiantes_documentos/manual-apa7.json
@@ -1,0 +1,9 @@
+{
+  "id": "manual-apa7",
+  "nombre": "Manual de Estilo APA 7ma Edición",
+  "descripcion": "Guía de citación y referencias bibliográficas",
+  "tipo": "pdf",
+  "categoria": "manual",
+  "url": "/documentos/manual-apa7.pdf",
+  "fechaActualizacion": "2023-12-01"
+}

--- a/src/content/estudiantes_documentos/reglamento-general.json
+++ b/src/content/estudiantes_documentos/reglamento-general.json
@@ -1,0 +1,9 @@
+{
+  "id": "reglamento-general",
+  "nombre": "Reglamento General de la EPG",
+  "descripcion": "Normativa general que rige el funcionamiento de la Escuela de Postgrado",
+  "tipo": "pdf",
+  "categoria": "reglamento",
+  "url": "/documentos/reglamento-general-epg.pdf",
+  "fechaActualizacion": "2024-03-15"
+}

--- a/src/content/estudiantes_documentos/reglamento-grados.json
+++ b/src/content/estudiantes_documentos/reglamento-grados.json
@@ -1,0 +1,9 @@
+{
+  "id": "reglamento-grados",
+  "nombre": "Reglamento de Grados y Títulos",
+  "descripcion": "Procedimientos para la obtención de grados académicos",
+  "tipo": "pdf",
+  "categoria": "reglamento",
+  "url": "/documentos/reglamento-grados-titulos.pdf",
+  "fechaActualizacion": "2024-02-20"
+}

--- a/src/content/estudiantes_documentos/solicitud-general.json
+++ b/src/content/estudiantes_documentos/solicitud-general.json
@@ -1,0 +1,9 @@
+{
+  "id": "solicitud-general",
+  "nombre": "Formato de Solicitud General (FUT)",
+  "descripcion": "Formulario único de trámite para diversas solicitudes",
+  "tipo": "docx",
+  "categoria": "formato",
+  "url": "/documentos/fut-solicitud-general.docx",
+  "fechaActualizacion": "2024-01-05"
+}

--- a/src/content/estudiantes_faq/faq-1.json
+++ b/src/content/estudiantes_faq/faq-1.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-1",
+  "pregunta": "¿Cuál es el plazo máximo para terminar la maestría?",
+  "respuesta": "El plazo máximo para culminar los estudios de maestría es de 4 años contados desde la fecha de ingreso. En casos excepcionales, se puede solicitar una ampliación de plazo presentando una solicitud debidamente justificada.",
+  "categoria": "general"
+}

--- a/src/content/estudiantes_faq/faq-2.json
+++ b/src/content/estudiantes_faq/faq-2.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-2",
+  "pregunta": "¿Cómo puedo solicitar una constancia de estudios?",
+  "respuesta": "Debe presentar una solicitud (FUT) en mesa de partes adjuntando el recibo de pago correspondiente (S/ 30.00). El documento estará listo en 3 a 5 días hábiles.",
+  "categoria": "tramites"
+}

--- a/src/content/estudiantes_faq/faq-3.json
+++ b/src/content/estudiantes_faq/faq-3.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-3",
+  "pregunta": "¿Cuántas veces puedo sustentar mi tesis si desapruebo?",
+  "respuesta": "El estudiante tiene derecho a dos (2) oportunidades adicionales para sustentar su tesis en caso de desaprobación. Cada nueva sustentación requiere un pago adicional por derecho de sustentación.",
+  "categoria": "tesis"
+}

--- a/src/content/estudiantes_faq/faq-4.json
+++ b/src/content/estudiantes_faq/faq-4.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-4",
+  "pregunta": "¿Puedo realizar pagos fraccionados?",
+  "respuesta": "Sí, la pensión de estudios puede pagarse en cuotas mensuales según el cronograma establecido por la EPG. El incumplimiento de pagos puede generar intereses y restricciones en el acceso a servicios académicos.",
+  "categoria": "pagos"
+}

--- a/src/content/estudiantes_faq/faq-5.json
+++ b/src/content/estudiantes_faq/faq-5.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-5",
+  "pregunta": "¿Qué porcentaje de similitud acepta Turnitin?",
+  "respuesta": "El porcentaje máximo de similitud permitido es del 25%. Si la tesis supera este porcentaje, deberá realizar las correcciones necesarias antes de poder sustentar.",
+  "categoria": "tesis"
+}

--- a/src/content/estudiantes_faq/faq-6.json
+++ b/src/content/estudiantes_faq/faq-6.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-6",
+  "pregunta": "¿Cómo solicito cambio de asesor de tesis?",
+  "respuesta": "Debe presentar una solicitud (FUT) indicando los motivos del cambio, adjuntando una carta de aceptación del nuevo asesor propuesto. La solicitud será evaluada por el Comité de Investigación.",
+  "categoria": "tesis"
+}

--- a/src/content/estudiantes_faq/faq-7.json
+++ b/src/content/estudiantes_faq/faq-7.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-7",
+  "pregunta": "¿Puedo matricularme en asignaturas de otro programa?",
+  "respuesta": "Sí, puede llevar asignaturas electivas de otros programas siempre que existan vacantes disponibles y cuente con la autorización del coordinador de su programa.",
+  "categoria": "matricula"
+}

--- a/src/content/estudiantes_faq/faq-8.json
+++ b/src/content/estudiantes_faq/faq-8.json
@@ -1,0 +1,6 @@
+{
+  "id": "faq-8",
+  "pregunta": "¿Qué pasa si no me matriculo en un semestre?",
+  "respuesta": "Si no se matricula en un semestre sin haber solicitado licencia, será considerado como abandono de estudios. Para reingresar, deberá solicitar reincorporación y regularizar su situación académica.",
+  "categoria": "matricula"
+}

--- a/src/content/estudiantes_recursos/bases-datos.json
+++ b/src/content/estudiantes_recursos/bases-datos.json
@@ -1,0 +1,8 @@
+{
+  "id": "bases-datos",
+  "nombre": "Bases de Datos Científicas",
+  "descripcion": "Scopus, Web of Science, Scielo y más",
+  "icono": "search",
+  "href": "/servicios/bases-datos",
+  "externo": false
+}

--- a/src/content/estudiantes_recursos/google-scholar.json
+++ b/src/content/estudiantes_recursos/google-scholar.json
@@ -1,0 +1,8 @@
+{
+  "id": "google-scholar",
+  "nombre": "Google Scholar",
+  "descripcion": "Buscador de literatura académica",
+  "icono": "graduation-cap",
+  "href": "https://scholar.google.com",
+  "externo": true
+}

--- a/src/content/estudiantes_recursos/mendeley.json
+++ b/src/content/estudiantes_recursos/mendeley.json
@@ -1,0 +1,8 @@
+{
+  "id": "mendeley",
+  "nombre": "Mendeley",
+  "descripcion": "Gestor de referencias bibliográficas",
+  "icono": "bookmark",
+  "href": "https://www.mendeley.com",
+  "externo": true
+}

--- a/src/content/estudiantes_recursos/orcid.json
+++ b/src/content/estudiantes_recursos/orcid.json
@@ -1,0 +1,8 @@
+{
+  "id": "orcid",
+  "nombre": "ORCID",
+  "descripcion": "Identificador de investigador",
+  "icono": "user-check",
+  "href": "https://orcid.org",
+  "externo": true
+}

--- a/src/content/estudiantes_recursos/repositorio-tesis.json
+++ b/src/content/estudiantes_recursos/repositorio-tesis.json
@@ -1,0 +1,8 @@
+{
+  "id": "repositorio-tesis",
+  "nombre": "Repositorio de Tesis",
+  "descripcion": "Acceso a tesis de maestría y doctorado",
+  "icono": "database",
+  "href": "https://repositorio.unapiquitos.edu.pe",
+  "externo": true
+}

--- a/src/content/estudiantes_recursos/turnitin.json
+++ b/src/content/estudiantes_recursos/turnitin.json
@@ -1,0 +1,8 @@
+{
+  "id": "turnitin",
+  "nombre": "Turnitin",
+  "descripcion": "Sistema de detección de similitud",
+  "icono": "shield-check",
+  "href": "https://www.turnitin.com",
+  "externo": true
+}

--- a/src/content/estudiantes_tramites/cambio-programa.json
+++ b/src/content/estudiantes_tramites/cambio-programa.json
@@ -1,0 +1,30 @@
+{
+  "id": "cambio-programa",
+  "nombre": "Cambio de Programa",
+  "descripcion": "Procedimiento para trasladarse a otro programa de la EPG.",
+  "icono": "shuffle",
+  "color": "bg-indigo-100",
+  "iconColor": "text-indigo-600",
+  "href": "/estudiantes/cambio-programa",
+  "requisitos": [
+    "Haber cursado al menos un semestre",
+    "Promedio mínimo de 14",
+    "Vacante disponible en el programa destino",
+    "Estar al día en pagos"
+  ],
+  "pasos": [
+    "Solicitar informe de estudios y notas",
+    "Presentar solicitud de cambio de programa",
+    "Esperar evaluación del Comité Académico",
+    "Recibir resolución de aprobación",
+    "Realizar convalidación de asignaturas"
+  ],
+  "documentos": [
+    "Solicitud dirigida al Director",
+    "Record de notas",
+    "Sílabos de asignaturas aprobadas",
+    "Carta de motivación"
+  ],
+  "costo": "S/ 150.00",
+  "duracion": "15-20 días hábiles"
+}

--- a/src/content/estudiantes_tramites/certificados.json
+++ b/src/content/estudiantes_tramites/certificados.json
@@ -1,0 +1,26 @@
+{
+  "id": "certificados",
+  "nombre": "Certificados y Constancias",
+  "descripcion": "Solicitud de documentos académicos oficiales.",
+  "icono": "file-text",
+  "color": "bg-red-100",
+  "iconColor": "text-red-600",
+  "href": "/estudiantes/certificados",
+  "requisitos": [
+    "Ser estudiante o egresado de la EPG",
+    "Estar al día en pagos"
+  ],
+  "pasos": [
+    "Realizar pago por derecho de certificado",
+    "Presentar solicitud con recibo de pago",
+    "Esperar procesamiento del documento",
+    "Recoger documento en mesa de partes"
+  ],
+  "documentos": [
+    "Solicitud simple",
+    "Recibo de pago",
+    "Copia de DNI"
+  ],
+  "costo": "S/ 30.00 - S/ 80.00",
+  "duracion": "3-5 días hábiles"
+}

--- a/src/content/estudiantes_tramites/licencia-estudios.json
+++ b/src/content/estudiantes_tramites/licencia-estudios.json
@@ -1,0 +1,26 @@
+{
+  "id": "licencia-estudios",
+  "nombre": "Licencia de Estudios",
+  "descripcion": "Solicitud de suspensión temporal de estudios por motivos justificados.",
+  "icono": "pause-circle",
+  "color": "bg-purple-100",
+  "iconColor": "text-purple-600",
+  "href": "/estudiantes/licencia-estudios",
+  "requisitos": [
+    "Estar matriculado en el semestre actual",
+    "Tener motivo justificado (salud, trabajo, viaje, etc.)",
+    "No tener deudas pendientes"
+  ],
+  "pasos": [
+    "Presentar solicitud en mesa de partes",
+    "Adjuntar documentos sustentatorios",
+    "Esperar resolución de la Dirección",
+    "Recibir resolución de licencia aprobada"
+  ],
+  "documentos": [
+    "Solicitud dirigida al Director",
+    "Documentos que justifiquen la licencia",
+    "Constancia de no adeudo"
+  ],
+  "duracion": "5-10 días hábiles"
+}

--- a/src/content/estudiantes_tramites/matricula.json
+++ b/src/content/estudiantes_tramites/matricula.json
@@ -1,0 +1,26 @@
+{
+  "id": "matricula",
+  "nombre": "Matrícula",
+  "descripcion": "Proceso de inscripción a las asignaturas del semestre académico.",
+  "icono": "clipboard-check",
+  "color": "bg-blue-100",
+  "iconColor": "text-blue-600",
+  "href": "/estudiantes/matricula",
+  "requisitos": [
+    "Estar al día en pagos",
+    "No tener deudas con biblioteca",
+    "Haber aprobado requisitos previos de las asignaturas"
+  ],
+  "pasos": [
+    "Ingresar al SIGAE con usuario y contraseña",
+    "Seleccionar \"Matrícula\" en el menú principal",
+    "Elegir las asignaturas disponibles",
+    "Confirmar matrícula y generar boleta de pago",
+    "Realizar el pago en ventanilla o banca electrónica"
+  ],
+  "documentos": [
+    "Constancia de no adeudo (si aplica)",
+    "Ficha de matrícula firmada"
+  ],
+  "duracion": "1-2 días hábiles"
+}

--- a/src/content/estudiantes_tramites/sustentaciones.json
+++ b/src/content/estudiantes_tramites/sustentaciones.json
@@ -1,0 +1,32 @@
+{
+  "id": "sustentaciones",
+  "nombre": "Sustentaciones",
+  "descripcion": "Cronograma y requisitos para la defensa de tesis.",
+  "icono": "users",
+  "color": "bg-green-100",
+  "iconColor": "text-green-600",
+  "href": "/estudiantes/sustentaciones",
+  "requisitos": [
+    "Proyecto de tesis aprobado",
+    "Informe de asesor con visto bueno",
+    "Revisión de similitud (Turnitin) menor al 25%",
+    "Constancia de no adeudo"
+  ],
+  "pasos": [
+    "Presentar borrador de tesis al asesor",
+    "Obtener visto bueno del asesor",
+    "Presentar solicitud de designación de jurado",
+    "Esperar resolución de designación de jurado",
+    "Entregar tesis a jurados para revisión",
+    "Levantar observaciones (si las hubiera)",
+    "Programar fecha de sustentación",
+    "Sustentar tesis ante el jurado"
+  ],
+  "documentos": [
+    "Tesis en formato PDF (4 ejemplares)",
+    "Informe del asesor",
+    "Constancia de Turnitin",
+    "Solicitud de sustentación"
+  ],
+  "duracion": "15-30 días hábiles"
+}

--- a/src/content/estudiantes_tramites/tramite-grado.json
+++ b/src/content/estudiantes_tramites/tramite-grado.json
@@ -1,0 +1,33 @@
+{
+  "id": "tramite-grado",
+  "nombre": "Trámite de Grado",
+  "descripcion": "Proceso para obtener el grado académico de Magíster o Doctor.",
+  "icono": "award",
+  "color": "bg-amber-100",
+  "iconColor": "text-amber-600",
+  "href": "/estudiantes/tramite-grado",
+  "requisitos": [
+    "Haber aprobado todas las asignaturas del plan de estudios",
+    "Tesis aprobada y sustentada",
+    "Constancia de no adeudo de biblioteca",
+    "Estar al día en pagos administrativos"
+  ],
+  "pasos": [
+    "Solicitar expedito en la Unidad de Postgrado",
+    "Presentar documentación completa en mesa de partes",
+    "Esperar revisión y aprobación del expediente",
+    "Participar en ceremonia de graduación o recojo individual"
+  ],
+  "documentos": [
+    "Solicitud dirigida al Director de la EPG",
+    "Acta de sustentación de tesis",
+    "Tesis empastada (3 ejemplares)",
+    "CD con tesis en formato digital",
+    "Constancia de no adeudo",
+    "Fotos tamaño pasaporte (6 unidades)",
+    "Copia de DNI",
+    "Recibo de pago por derechos de grado"
+  ],
+  "costo": "S/ 500.00",
+  "duracion": "30-45 días hábiles"
+}

--- a/src/data/estudiantes.ts
+++ b/src/data/estudiantes.ts
@@ -1,570 +1,77 @@
-// ============================================
-// DATOS MOCK - Portal del Estudiante
-// ============================================
+import { getCollection, getEntry } from 'astro:content';
+import type { 
+  AccesoRapido, 
+  TramiteEstudiantil, 
+  DocumentoDescargable, 
+  FechaCalendario, 
+  RecursoAcademico, 
+  PreguntaFrecuente 
+} from '@/types'; // Need to define or keep these in types/
 
-export interface AccesoRapido {
-  id: string;
-  nombre: string;
-  descripcion: string;
-  icono: 'clipboard' | 'monitor' | 'book-open' | 'mail' | 'calendar' | 'file-text' | 'users' | 'award';
-  href: string;
-  color: string; // Tailwind color class
+export async function getAccesosRapidos(): Promise<AccesoRapido[]> {
+  const collection = await getCollection('estudiantes_accesos');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as AccesoRapido[];
 }
 
-export interface TramiteEstudiantil {
-  id: string;
-  nombre: string;
-  descripcion: string;
-  icono: 'clipboard-check' | 'award' | 'users' | 'pause-circle' | 'shuffle' | 'file-text' | 'graduation-cap' | 'credit-card';
-  color: string; // bg color class
-  iconColor: string; // icon color class
-  href: string;
-  requisitos: string[];
-  pasos: string[];
-  documentos: string[];
-  costo?: string;
-  duracion?: string;
+export async function getTramitesEstudiantiles(): Promise<TramiteEstudiantil[]> {
+  const collection = await getCollection('estudiantes_tramites');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as TramiteEstudiantil[];
 }
 
-export interface DocumentoDescargable {
-  id: string;
-  nombre: string;
-  descripcion: string;
-  tipo: 'pdf' | 'docx' | 'xlsx';
-  categoria: 'reglamento' | 'formato' | 'guia' | 'manual';
-  url: string;
-  fechaActualizacion: string;
+export async function getDocumentosDescargables(): Promise<DocumentoDescargable[]> {
+  const collection = await getCollection('estudiantes_documentos');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as DocumentoDescargable[];
 }
 
-export interface FechaCalendario {
-  id: string;
-  titulo: string;
-  descripcion: string;
-  fechaInicio: string;
-  fechaFin?: string;
-  tipo: 'matricula' | 'examen' | 'sustentacion' | 'vacaciones' | 'evento' | 'pago';
-  importante: boolean;
+export async function getCalendarioAcademico(): Promise<FechaCalendario[]> {
+  const collection = await getCollection('estudiantes_calendario');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as FechaCalendario[];
 }
 
-export interface RecursoAcademico {
-  id: string;
-  nombre: string;
-  descripcion: string;
-  icono: string;
-  href: string;
-  externo: boolean;
+export async function getRecursosAcademicos(): Promise<RecursoAcademico[]> {
+  const collection = await getCollection('estudiantes_recursos');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as RecursoAcademico[];
 }
 
-export interface PreguntaFrecuente {
-  id: string;
-  pregunta: string;
-  respuesta: string;
-  categoria: 'matricula' | 'tramites' | 'tesis' | 'pagos' | 'general';
+export async function getPreguntasFrecuentes(): Promise<PreguntaFrecuente[]> {
+  const collection = await getCollection('estudiantes_faq');
+  return collection.map(entry => ({ ...entry.data, id: entry.id })) as PreguntaFrecuente[];
 }
 
-// ============================================
-// ACCESOS RÁPIDOS
-// ============================================
-export const accesosRapidos: AccesoRapido[] = [
-  {
-    id: 'sigae',
-    nombre: 'SIGAE',
-    descripcion: 'Sistema Integrado de Gestión Académica',
-    icono: 'clipboard',
-    href: 'https://sigae.unapiquitos.edu.pe',
-    color: 'bg-epg-navy'
-  },
-  {
-    id: 'aula-virtual',
-    nombre: 'Aula Virtual',
-    descripcion: 'Plataforma de aprendizaje en línea',
-    icono: 'monitor',
-    href: 'https://aulavirtual.unapiquitos.edu.pe',
-    color: 'bg-epg-navy'
-  },
-  {
-    id: 'biblioteca',
-    nombre: 'Biblioteca Virtual',
-    descripcion: 'Acceso a recursos bibliográficos',
-    icono: 'book-open',
-    href: 'https://biblioteca.unapiquitos.edu.pe',
-    color: 'bg-epg-navy'
-  },
-  {
-    id: 'correo',
-    nombre: 'Correo Institucional',
-    descripcion: 'Email @unapiquitos.edu.pe',
-    icono: 'mail',
-    href: 'https://mail.google.com',
-    color: 'bg-epg-navy'
-  }
-];
-
-// ============================================
-// TRÁMITES ESTUDIANTILES
-// ============================================
-export const tramitesEstudiantiles: TramiteEstudiantil[] = [
-  {
-    id: 'matricula',
-    nombre: 'Matrícula',
-    descripcion: 'Proceso de inscripción a las asignaturas del semestre académico.',
-    icono: 'clipboard-check',
-    color: 'bg-blue-100',
-    iconColor: 'text-blue-600',
-    href: '/estudiantes/matricula',
-    requisitos: [
-      'Estar al día en pagos',
-      'No tener deudas con biblioteca',
-      'Haber aprobado requisitos previos de las asignaturas'
-    ],
-    pasos: [
-      'Ingresar al SIGAE con usuario y contraseña',
-      'Seleccionar "Matrícula" en el menú principal',
-      'Elegir las asignaturas disponibles',
-      'Confirmar matrícula y generar boleta de pago',
-      'Realizar el pago en ventanilla o banca electrónica'
-    ],
-    documentos: [
-      'Constancia de no adeudo (si aplica)',
-      'Ficha de matrícula firmada'
-    ],
-    duracion: '1-2 días hábiles'
-  },
-  {
-    id: 'tramite-grado',
-    nombre: 'Trámite de Grado',
-    descripcion: 'Proceso para obtener el grado académico de Magíster o Doctor.',
-    icono: 'award',
-    color: 'bg-amber-100',
-    iconColor: 'text-amber-600',
-    href: '/estudiantes/tramite-grado',
-    requisitos: [
-      'Haber aprobado todas las asignaturas del plan de estudios',
-      'Tesis aprobada y sustentada',
-      'Constancia de no adeudo de biblioteca',
-      'Estar al día en pagos administrativos'
-    ],
-    pasos: [
-      'Solicitar expedito en la Unidad de Postgrado',
-      'Presentar documentación completa en mesa de partes',
-      'Esperar revisión y aprobación del expediente',
-      'Participar en ceremonia de graduación o recojo individual'
-    ],
-    documentos: [
-      'Solicitud dirigida al Director de la EPG',
-      'Acta de sustentación de tesis',
-      'Tesis empastada (3 ejemplares)',
-      'CD con tesis en formato digital',
-      'Constancia de no adeudo',
-      'Fotos tamaño pasaporte (6 unidades)',
-      'Copia de DNI',
-      'Recibo de pago por derechos de grado'
-    ],
-    costo: 'S/ 500.00',
-    duracion: '30-45 días hábiles'
-  },
-  {
-    id: 'sustentaciones',
-    nombre: 'Sustentaciones',
-    descripcion: 'Cronograma y requisitos para la defensa de tesis.',
-    icono: 'users',
-    color: 'bg-green-100',
-    iconColor: 'text-green-600',
-    href: '/estudiantes/sustentaciones',
-    requisitos: [
-      'Proyecto de tesis aprobado',
-      'Informe de asesor con visto bueno',
-      'Revisión de similitud (Turnitin) menor al 25%',
-      'Constancia de no adeudo'
-    ],
-    pasos: [
-      'Presentar borrador de tesis al asesor',
-      'Obtener visto bueno del asesor',
-      'Presentar solicitud de designación de jurado',
-      'Esperar resolución de designación de jurado',
-      'Entregar tesis a jurados para revisión',
-      'Levantar observaciones (si las hubiera)',
-      'Programar fecha de sustentación',
-      'Sustentar tesis ante el jurado'
-    ],
-    documentos: [
-      'Tesis en formato PDF (4 ejemplares)',
-      'Informe del asesor',
-      'Constancia de Turnitin',
-      'Solicitud de sustentación'
-    ],
-    duracion: '15-30 días hábiles'
-  },
-  {
-    id: 'licencia-estudios',
-    nombre: 'Licencia de Estudios',
-    descripcion: 'Solicitud de suspensión temporal de estudios por motivos justificados.',
-    icono: 'pause-circle',
-    color: 'bg-purple-100',
-    iconColor: 'text-purple-600',
-    href: '/estudiantes/licencia-estudios',
-    requisitos: [
-      'Estar matriculado en el semestre actual',
-      'Tener motivo justificado (salud, trabajo, viaje, etc.)',
-      'No tener deudas pendientes'
-    ],
-    pasos: [
-      'Presentar solicitud en mesa de partes',
-      'Adjuntar documentos sustentatorios',
-      'Esperar resolución de la Dirección',
-      'Recibir resolución de licencia aprobada'
-    ],
-    documentos: [
-      'Solicitud dirigida al Director',
-      'Documentos que justifiquen la licencia',
-      'Constancia de no adeudo'
-    ],
-    duracion: '5-10 días hábiles'
-  },
-  {
-    id: 'cambio-programa',
-    nombre: 'Cambio de Programa',
-    descripcion: 'Procedimiento para trasladarse a otro programa de la EPG.',
-    icono: 'shuffle',
-    color: 'bg-indigo-100',
-    iconColor: 'text-indigo-600',
-    href: '/estudiantes/cambio-programa',
-    requisitos: [
-      'Haber cursado al menos un semestre',
-      'Promedio mínimo de 14',
-      'Vacante disponible en el programa destino',
-      'Estar al día en pagos'
-    ],
-    pasos: [
-      'Solicitar informe de estudios y notas',
-      'Presentar solicitud de cambio de programa',
-      'Esperar evaluación del Comité Académico',
-      'Recibir resolución de aprobación',
-      'Realizar convalidación de asignaturas'
-    ],
-    documentos: [
-      'Solicitud dirigida al Director',
-      'Record de notas',
-      'Sílabos de asignaturas aprobadas',
-      'Carta de motivación'
-    ],
-    costo: 'S/ 150.00',
-    duracion: '15-20 días hábiles'
-  },
-  {
-    id: 'certificados',
-    nombre: 'Certificados y Constancias',
-    descripcion: 'Solicitud de documentos académicos oficiales.',
-    icono: 'file-text',
-    color: 'bg-red-100',
-    iconColor: 'text-red-600',
-    href: '/estudiantes/certificados',
-    requisitos: [
-      'Ser estudiante o egresado de la EPG',
-      'Estar al día en pagos'
-    ],
-    pasos: [
-      'Realizar pago por derecho de certificado',
-      'Presentar solicitud con recibo de pago',
-      'Esperar procesamiento del documento',
-      'Recoger documento en mesa de partes'
-    ],
-    documentos: [
-      'Solicitud simple',
-      'Recibo de pago',
-      'Copia de DNI'
-    ],
-    costo: 'S/ 30.00 - S/ 80.00',
-    duracion: '3-5 días hábiles'
-  }
-];
-
-// ============================================
-// DOCUMENTOS DESCARGABLES
-// ============================================
-export const documentosDescargables: DocumentoDescargable[] = [
-  {
-    id: 'reglamento-general',
-    nombre: 'Reglamento General de la EPG',
-    descripcion: 'Normativa general que rige el funcionamiento de la Escuela de Postgrado',
-    tipo: 'pdf',
-    categoria: 'reglamento',
-    url: '/documentos/reglamento-general-epg.pdf',
-    fechaActualizacion: '2024-03-15'
-  },
-  {
-    id: 'reglamento-grados',
-    nombre: 'Reglamento de Grados y Títulos',
-    descripcion: 'Procedimientos para la obtención de grados académicos',
-    tipo: 'pdf',
-    categoria: 'reglamento',
-    url: '/documentos/reglamento-grados-titulos.pdf',
-    fechaActualizacion: '2024-02-20'
-  },
-  {
-    id: 'formato-proyecto-tesis',
-    nombre: 'Formato de Proyecto de Tesis',
-    descripcion: 'Plantilla oficial para la presentación del proyecto de investigación',
-    tipo: 'docx',
-    categoria: 'formato',
-    url: '/documentos/formato-proyecto-tesis.docx',
-    fechaActualizacion: '2024-01-10'
-  },
-  {
-    id: 'guia-elaboracion-tesis',
-    nombre: 'Guía de Elaboración de Tesis',
-    descripcion: 'Manual con lineamientos para la redacción de tesis',
-    tipo: 'pdf',
-    categoria: 'guia',
-    url: '/documentos/guia-elaboracion-tesis.pdf',
-    fechaActualizacion: '2024-03-01'
-  },
-  {
-    id: 'formato-informe-asesor',
-    nombre: 'Formato de Informe de Asesor',
-    descripcion: 'Plantilla para el informe de avance del asesor de tesis',
-    tipo: 'docx',
-    categoria: 'formato',
-    url: '/documentos/formato-informe-asesor.docx',
-    fechaActualizacion: '2024-02-15'
-  },
-  {
-    id: 'solicitud-general',
-    nombre: 'Formato de Solicitud General (FUT)',
-    descripcion: 'Formulario único de trámite para diversas solicitudes',
-    tipo: 'docx',
-    categoria: 'formato',
-    url: '/documentos/fut-solicitud-general.docx',
-    fechaActualizacion: '2024-01-05'
-  },
-  {
-    id: 'manual-apa7',
-    nombre: 'Manual de Estilo APA 7ma Edición',
-    descripcion: 'Guía de citación y referencias bibliográficas',
-    tipo: 'pdf',
-    categoria: 'manual',
-    url: '/documentos/manual-apa7.pdf',
-    fechaActualizacion: '2023-12-01'
-  },
-  {
-    id: 'formato-constancia-no-adeudo',
-    nombre: 'Solicitud de Constancia de No Adeudo',
-    descripcion: 'Formato para solicitar constancia de no adeudo',
-    tipo: 'docx',
-    categoria: 'formato',
-    url: '/documentos/solicitud-constancia-no-adeudo.docx',
-    fechaActualizacion: '2024-01-20'
-  }
-];
-
-// ============================================
-// CALENDARIO ACADÉMICO
-// ============================================
-export const calendarioAcademico: FechaCalendario[] = [
-  {
-    id: 'matricula-2026-1',
-    titulo: 'Matrícula Regular 2026-I',
-    descripcion: 'Periodo de matrícula para el semestre 2026-I',
-    fechaInicio: '2026-05-18',
-    fechaFin: '2026-05-29',
-    tipo: 'matricula',
-    importante: true
-  },
-  {
-    id: 'inicio-clases-2026-1',
-    titulo: 'Inicio de Clases 2026-I',
-    descripcion: 'Inicio del semestre académico 2026-I',
-    fechaInicio: '2026-06-01',
-    tipo: 'evento',
-    importante: true
-  },
-  {
-    id: 'examen-parcial-2026-1',
-    titulo: 'Exámenes Parciales 2026-I',
-    descripcion: 'Semana de evaluaciones parciales',
-    fechaInicio: '2026-07-20',
-    fechaFin: '2026-07-25',
-    tipo: 'examen',
-    importante: true
-  },
-  {
-    id: 'pago-cuota2-2026-1',
-    titulo: 'Fecha límite pago 2da cuota',
-    descripcion: 'Último día para pagar la segunda cuota del semestre',
-    fechaInicio: '2026-07-10',
-    tipo: 'pago',
-    importante: true
-  },
-  {
-    id: 'examen-final-2026-1',
-    titulo: 'Exámenes Finales 2026-I',
-    descripcion: 'Semana de evaluaciones finales',
-    fechaInicio: '2026-09-28',
-    fechaFin: '2026-10-03',
-    tipo: 'examen',
-    importante: true
-  },
-  {
-    id: 'sustentaciones-septiembre',
-    titulo: 'Sustentaciones de Tesis - Septiembre',
-    descripcion: 'Periodo programado para sustentaciones de tesis',
-    fechaInicio: '2026-09-14',
-    fechaFin: '2026-09-25',
-    tipo: 'sustentacion',
-    importante: false
-  },
-  {
-    id: 'vacaciones-medio-año',
-    titulo: 'Vacaciones de Medio Año',
-    descripcion: 'Periodo de vacaciones entre semestres',
-    fechaInicio: '2026-08-10',
-    fechaFin: '2026-08-23',
-    tipo: 'vacaciones',
-    importante: false
-  },
-  {
-    id: 'matricula-2026-2',
-    titulo: 'Matrícula Regular 2026-II',
-    descripcion: 'Periodo de matrícula para el semestre 2026-II',
-    fechaInicio: '2026-10-19',
-    fechaFin: '2026-10-30',
-    tipo: 'matricula',
-    importante: true
-  }
-];
-
-// ============================================
-// RECURSOS ACADÉMICOS
-// ============================================
-export const recursosAcademicos: RecursoAcademico[] = [
-  {
-    id: 'repositorio-tesis',
-    nombre: 'Repositorio de Tesis',
-    descripcion: 'Acceso a tesis de maestría y doctorado',
-    icono: 'database',
-    href: 'https://repositorio.unapiquitos.edu.pe',
-    externo: true
-  },
-  {
-    id: 'bases-datos',
-    nombre: 'Bases de Datos Científicas',
-    descripcion: 'Scopus, Web of Science, Scielo y más',
-    icono: 'search',
-    href: '/servicios/bases-datos',
-    externo: false
-  },
-  {
-    id: 'turnitin',
-    nombre: 'Turnitin',
-    descripcion: 'Sistema de detección de similitud',
-    icono: 'shield-check',
-    href: 'https://www.turnitin.com',
-    externo: true
-  },
-  {
-    id: 'mendeley',
-    nombre: 'Mendeley',
-    descripcion: 'Gestor de referencias bibliográficas',
-    icono: 'bookmark',
-    href: 'https://www.mendeley.com',
-    externo: true
-  },
-  {
-    id: 'google-scholar',
-    nombre: 'Google Scholar',
-    descripcion: 'Buscador de literatura académica',
-    icono: 'graduation-cap',
-    href: 'https://scholar.google.com',
-    externo: true
-  },
-  {
-    id: 'orcid',
-    nombre: 'ORCID',
-    descripcion: 'Identificador de investigador',
-    icono: 'user-check',
-    href: 'https://orcid.org',
-    externo: true
-  }
-];
-
-// ============================================
-// PREGUNTAS FRECUENTES
-// ============================================
-export const preguntasFrecuentes: PreguntaFrecuente[] = [
-  {
-    id: 'faq-1',
-    pregunta: '¿Cuál es el plazo máximo para terminar la maestría?',
-    respuesta: 'El plazo máximo para culminar los estudios de maestría es de 4 años contados desde la fecha de ingreso. En casos excepcionales, se puede solicitar una ampliación de plazo presentando una solicitud debidamente justificada.',
-    categoria: 'general'
-  },
-  {
-    id: 'faq-2',
-    pregunta: '¿Cómo puedo solicitar una constancia de estudios?',
-    respuesta: 'Debe presentar una solicitud (FUT) en mesa de partes adjuntando el recibo de pago correspondiente (S/ 30.00). El documento estará listo en 3 a 5 días hábiles.',
-    categoria: 'tramites'
-  },
-  {
-    id: 'faq-3',
-    pregunta: '¿Cuántas veces puedo sustentar mi tesis si desapruebo?',
-    respuesta: 'El estudiante tiene derecho a dos (2) oportunidades adicionales para sustentar su tesis en caso de desaprobación. Cada nueva sustentación requiere un pago adicional por derecho de sustentación.',
-    categoria: 'tesis'
-  },
-  {
-    id: 'faq-4',
-    pregunta: '¿Puedo realizar pagos fraccionados?',
-    respuesta: 'Sí, la pensión de estudios puede pagarse en cuotas mensuales según el cronograma establecido por la EPG. El incumplimiento de pagos puede generar intereses y restricciones en el acceso a servicios académicos.',
-    categoria: 'pagos'
-  },
-  {
-    id: 'faq-5',
-    pregunta: '¿Qué porcentaje de similitud acepta Turnitin?',
-    respuesta: 'El porcentaje máximo de similitud permitido es del 25%. Si la tesis supera este porcentaje, deberá realizar las correcciones necesarias antes de poder sustentar.',
-    categoria: 'tesis'
-  },
-  {
-    id: 'faq-6',
-    pregunta: '¿Cómo solicito cambio de asesor de tesis?',
-    respuesta: 'Debe presentar una solicitud (FUT) indicando los motivos del cambio, adjuntando una carta de aceptación del nuevo asesor propuesto. La solicitud será evaluada por el Comité de Investigación.',
-    categoria: 'tesis'
-  },
-  {
-    id: 'faq-7',
-    pregunta: '¿Puedo matricularme en asignaturas de otro programa?',
-    respuesta: 'Sí, puede llevar asignaturas electivas de otros programas siempre que existan vacantes disponibles y cuente con la autorización del coordinador de su programa.',
-    categoria: 'matricula'
-  },
-  {
-    id: 'faq-8',
-    pregunta: '¿Qué pasa si no me matriculo en un semestre?',
-    respuesta: 'Si no se matricula en un semestre sin haber solicitado licencia, será considerado como abandono de estudios. Para reingresar, deberá solicitar reincorporación y regularizar su situación académica.',
-    categoria: 'matricula'
-  }
-];
-
-// ============================================
-// HELPERS / FUNCIONES ÚTILES
-// ============================================
-
-export function getTramiteById(id: string): TramiteEstudiantil | undefined {
-  return tramitesEstudiantiles.find(t => t.id === id);
+export async function getTramiteById(id: string): Promise<TramiteEstudiantil | undefined> {
+  const all = await getTramitesEstudiantiles();
+  return all.find(t => t.id === id);
 }
 
-export function getDocumentosByCategoria(categoria: DocumentoDescargable['categoria']): DocumentoDescargable[] {
-  return documentosDescargables.filter(d => d.categoria === categoria);
+export async function getDocumentosByCategoria(categoria: DocumentoDescargable['categoria']): Promise<DocumentoDescargable[]> {
+  const all = await getDocumentosDescargables();
+  return all.filter(d => d.categoria === categoria);
 }
 
-export function getFechasImportantes(): FechaCalendario[] {
-  return calendarioAcademico.filter(f => f.importante);
+export async function getFechasImportantes(): Promise<FechaCalendario[]> {
+  const all = await getCalendarioAcademico();
+  return all.filter(f => f.importante);
 }
 
-export function getPreguntasByCategoria(categoria: PreguntaFrecuente['categoria']): PreguntaFrecuente[] {
-  return preguntasFrecuentes.filter(p => p.categoria === categoria);
+export async function getPreguntasByCategoria(categoria: PreguntaFrecuente['categoria']): Promise<PreguntaFrecuente[]> {
+  const all = await getPreguntasFrecuentes();
+  return all.filter(p => p.categoria === categoria);
 }
 
-export function getProximasFechas(cantidad: number = 5): FechaCalendario[] {
+export async function getProximasFechas(cantidad: number = 5): Promise<FechaCalendario[]> {
   const hoy = new Date();
-  return calendarioAcademico
+  const all = await getCalendarioAcademico();
+  return all
     .filter(f => new Date(f.fechaInicio) >= hoy)
     .sort((a, b) => new Date(a.fechaInicio).getTime() - new Date(b.fechaInicio).getTime())
     .slice(0, cantidad);
+}
+
+export type {
+  AccesoRapido,
+  TramiteEstudiantil,
+  DocumentoDescargable,
+  FechaCalendario,
+  RecursoAcademico,
+  PreguntaFrecuente
 }

--- a/src/features/estudiantes/components/EstudiantesContent.tsx
+++ b/src/features/estudiantes/components/EstudiantesContent.tsx
@@ -1,16 +1,12 @@
 import { useState } from 'react';
-import {
-  accesosRapidos,
-  tramitesEstudiantiles,
-  documentosDescargables,
-  calendarioAcademico,
-  recursosAcademicos,
-  preguntasFrecuentes,
-  type TramiteEstudiantil,
-  type DocumentoDescargable,
-  type FechaCalendario,
-  type PreguntaFrecuente,
-} from '@/data/estudiantes';
+import type {
+  AccesoRapido,
+  TramiteEstudiantil,
+  DocumentoDescargable,
+  FechaCalendario,
+  RecursoAcademico,
+  PreguntaFrecuente,
+} from '@/types';
 import {
   ClipboardList,
   Monitor,
@@ -94,7 +90,7 @@ const recursoIconMap: Record<string, React.ReactNode> = {
 // ========================================
 // ACCESOS RÁPIDOS COMPONENT
 // ========================================
-function AccesosRapidos() {
+function AccesosRapidos({ items }: { items: AccesoRapido[] }) {
   return (
     <section className="py-12 lg:py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -107,7 +103,7 @@ function AccesosRapidos() {
         />
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-          {accesosRapidos.map((acceso) => (
+          {items.map((acceso) => (
             <a
               key={acceso.id}
               href={acceso.href}
@@ -139,7 +135,7 @@ function AccesosRapidos() {
 // ========================================
 // TRÁMITES COMPONENT
 // ========================================
-function TramitesGrid() {
+function TramitesGrid({ items }: { items: TramiteEstudiantil[] }) {
   const [selectedTramite, setSelectedTramite] =
     useState<TramiteEstudiantil | null>(null);
 
@@ -156,7 +152,7 @@ function TramitesGrid() {
         />
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {tramitesEstudiantiles.map((tramite) => {
+          {items.map((tramite) => {
             const IconComponent = tramiteIconMap[tramite.icono];
             return (
               <Card
@@ -288,7 +284,7 @@ function TramitesGrid() {
 // ========================================
 // DOCUMENTOS COMPONENT
 // ========================================
-function DocumentosDescargables() {
+function DocumentosDescargables({ items }: { items: DocumentoDescargable[] }) {
   const tipoIcon: Record<
     DocumentoDescargable['tipo'],
     { bg: string; text: string }
@@ -316,7 +312,7 @@ function DocumentosDescargables() {
         />
 
         <div className="grid md:grid-cols-2 gap-4">
-          {documentosDescargables.map((doc) => (
+          {items.map((doc) => (
             <DocumentDownloadItem
               key={doc.id}
               name={doc.nombre}
@@ -344,7 +340,7 @@ function DocumentosDescargables() {
 // ========================================
 // CALENDARIO COMPONENT
 // ========================================
-function CalendarioAcademico() {
+function CalendarioAcademico({ items }: { items: FechaCalendario[] }) {
   const tipoStyles: Record<
     FechaCalendario['tipo'],
     { bg: string; text: string; label: string }
@@ -385,7 +381,7 @@ function CalendarioAcademico() {
         />
 
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {calendarioAcademico.slice(0, 8).map((fecha) => {
+          {items.slice(0, 8).map((fecha) => {
             const style = tipoStyles[fecha.tipo];
             return (
               <Card
@@ -434,7 +430,7 @@ function CalendarioAcademico() {
 // ========================================
 // RECURSOS ACADÉMICOS COMPONENT
 // ========================================
-function RecursosAcademicosGrid() {
+function RecursosAcademicosGrid({ items }: { items: RecursoAcademico[] }) {
   return (
     <section className="py-12 lg:py-16 bg-epg-navy">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -447,7 +443,7 @@ function RecursosAcademicosGrid() {
         />
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-          {recursosAcademicos.map((recurso) => (
+          {items.map((recurso) => (
             <a
               key={recurso.id}
               href={recurso.href}
@@ -477,7 +473,7 @@ function RecursosAcademicosGrid() {
 // ========================================
 // FAQ COMPONENT
 // ========================================
-function PreguntasFrecuentesSection() {
+function PreguntasFrecuentesSection({ items }: { items: PreguntaFrecuente[] }) {
   const categoriaLabels: Record<PreguntaFrecuente['categoria'], string> = {
     matricula: 'Matrícula',
     tramites: 'Trámites',
@@ -486,7 +482,7 @@ function PreguntasFrecuentesSection() {
     general: 'General',
   };
 
-  const accordionItems: AccordionItem[] = preguntasFrecuentes.map((faq) => ({
+  const accordionItems: AccordionItem[] = items.map((faq) => ({
     id: faq.id,
     title: (
       <div className="flex items-center gap-3">
@@ -565,7 +561,23 @@ function CtaSection() {
 // ========================================
 // MAIN EXPORT COMPONENT
 // ========================================
-export function EstudiantesContent() {
+export interface EstudiantesContentProps {
+  accesosRapidos: AccesoRapido[];
+  tramites: TramiteEstudiantil[];
+  calendario: FechaCalendario[];
+  documentos: DocumentoDescargable[];
+  recursos: RecursoAcademico[];
+  faq: PreguntaFrecuente[];
+}
+
+export function EstudiantesContent({
+  accesosRapidos,
+  tramites,
+  calendario,
+  documentos,
+  recursos,
+  faq,
+}: EstudiantesContentProps) {
   return (
     <div>
       {/* Hero Section */}
@@ -578,22 +590,22 @@ export function EstudiantesContent() {
       />
 
       {/* Accesos Rápidos */}
-      <AccesosRapidos />
+      <AccesosRapidos items={accesosRapidos} />
 
       {/* Trámites */}
-      <TramitesGrid />
+      <TramitesGrid items={tramites} />
 
       {/* Calendario */}
-      <CalendarioAcademico />
+      <CalendarioAcademico items={calendario} />
 
       {/* Documentos */}
-      <DocumentosDescargables />
+      <DocumentosDescargables items={documentos} />
 
       {/* Recursos Académicos */}
-      <RecursosAcademicosGrid />
+      <RecursosAcademicosGrid items={recursos} />
 
       {/* FAQ */}
-      <PreguntasFrecuentesSection />
+      <PreguntasFrecuentesSection items={faq} />
 
       {/* CTA */}
       <CtaSection />

--- a/src/pages/estudiantes/index.astro
+++ b/src/pages/estudiantes/index.astro
@@ -3,6 +3,22 @@ import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';
 import { EstudiantesContent } from '../../features/estudiantes';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+
+import {
+  getAccesosRapidos,
+  getTramitesEstudiantiles,
+  getCalendarioAcademico,
+  getDocumentosDescargables,
+  getRecursosAcademicos,
+  getPreguntasFrecuentes,
+} from '../../data/estudiantes';
+
+const accesosRapidos = await getAccesosRapidos();
+const tramites = await getTramitesEstudiantiles();
+const calendario = await getCalendarioAcademico();
+const documentos = await getDocumentosDescargables();
+const recursos = await getRecursosAcademicos();
+const faq = await getPreguntasFrecuentes();
 ---
 
 <Layout 
@@ -13,7 +29,15 @@ import { ErrorBoundary } from '../../components/ui/error-boundary';
   <Navbar />
   <main class="min-h-screen">
     <ErrorBoundary client:load>
-      <EstudiantesContent client:load />
+      <EstudiantesContent 
+        client:load 
+        accesosRapidos={accesosRapidos}
+        tramites={tramites}
+        calendario={calendario}
+        documentos={documentos}
+        recursos={recursos}
+        faq={faq}
+      />
     </ErrorBoundary>
   </main>
 </Layout>

--- a/src/types/estudiantes.ts
+++ b/src/types/estudiantes.ts
@@ -25,3 +25,63 @@ export interface Sustentacion {
   asesor: string;
   tipo: 'tesis' | 'proyecto' | 'trabajo_investigacion';
 }
+
+export interface AccesoRapido {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  icono: 'clipboard' | 'monitor' | 'book-open' | 'mail' | 'calendar' | 'file-text' | 'users' | 'award';
+  href: string;
+  color: string; // Tailwind color class
+}
+
+export interface TramiteEstudiantil {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  icono: 'clipboard-check' | 'award' | 'users' | 'pause-circle' | 'shuffle' | 'file-text' | 'graduation-cap' | 'credit-card';
+  color: string; // bg color class
+  iconColor: string; // icon color class
+  href: string;
+  requisitos: string[];
+  pasos: string[];
+  documentos: string[];
+  costo?: string;
+  duracion?: string;
+}
+
+export interface DocumentoDescargable {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  tipo: 'pdf' | 'docx' | 'xlsx';
+  categoria: 'reglamento' | 'formato' | 'guia' | 'manual';
+  url: string;
+  fechaActualizacion: string;
+}
+
+export interface FechaCalendario {
+  id: string;
+  titulo: string;
+  descripcion: string;
+  fechaInicio: string;
+  fechaFin?: string;
+  tipo: 'matricula' | 'examen' | 'sustentacion' | 'vacaciones' | 'evento' | 'pago';
+  importante: boolean;
+}
+
+export interface RecursoAcademico {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  icono: string;
+  href: string;
+  externo: boolean;
+}
+
+export interface PreguntaFrecuente {
+  id: string;
+  pregunta: string;
+  respuesta: string;
+  categoria: 'matricula' | 'tramites' | 'tesis' | 'pagos' | 'general';
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,12 @@ export type {
 export type {
   ProcesoEstudiantil,
   Sustentacion,
+  AccesoRapido,
+  TramiteEstudiantil,
+  DocumentoDescargable,
+  FechaCalendario,
+  RecursoAcademico,
+  PreguntaFrecuente,
 } from './estudiantes';
 
 // Institucional


### PR DESCRIPTION
## Summary
- Created 6 new Zod schemas in `src/content/config.ts` for the various estudiante sub-collections (`estudiantes_accesos`, `estudiantes_tramites`, `estudiantes_documentos`, `estudiantes_calendario`, `estudiantes_recursos`, and `estudiantes_faq`).
- Created and executed `scripts/seeder/estudiantes.ts` to generate deterministic JSON seed data.
- Moved interfaces (`AccesoRapido`, `TramiteEstudiantil`, etc.) into `src/types/estudiantes.ts` and exported them.
- Rewrote `src/data/estudiantes.ts` to fetch data asynchronously from the content collections.
- Updated `EstudiantesContent.tsx` and `src/pages/estudiantes/index.astro` to pass data as props.
- Resolves #256