### PR TITLE
refactor: migrate admision data to content collections (#257)

### DIFF
--- a/scripts/seeder/admision.ts
+++ b/scripts/seeder/admision.ts
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { ProcesoAdmision } from '../../src/types';
+
+const procesosAdmision: ProcesoAdmision[] = [
+  {
+    id: 'adm-2026-I',
+    periodo: '2026-I',
+    anio: 2026,
+    fechaApertura: '2026-03-16',
+    fechaCierre: '2026-04-30',
+    fechasImportantes: [
+      {
+        etiqueta: 'Inscripciones',
+        fechaInicio: '2026-03-16',
+        fechaFin: '2026-04-30',
+        descripcion: 'Período de inscripciones para el proceso de admisión',
+      },
+      {
+        etiqueta: 'Examen de admisión',
+        fechaInicio: '2026-05-09',
+        descripcion: 'Evaluación de conocimientos',
+      },
+      {
+        etiqueta: 'Resultados',
+        fechaInicio: '2026-05-13',
+        descripcion: 'Publicación de resultados',
+      },
+      {
+        etiqueta: 'Inicio de clases',
+        fechaInicio: '2026-06-01',
+        descripcion: 'Comienzo del semestre académico',
+      },
+    ],
+  },
+  {
+    id: 'adm-2026-II',
+    periodo: '2026-II',
+    anio: 2026,
+    fechaApertura: '2026-08-03',
+    fechaCierre: '2026-09-18',
+    fechasImportantes: [
+      {
+        etiqueta: 'Inscripciones',
+        fechaInicio: '2026-08-03',
+        fechaFin: '2026-09-18',
+      },
+      {
+        etiqueta: 'Examen de admisión',
+        fechaInicio: '2026-10-03',
+      },
+      {
+        etiqueta: 'Resultados',
+        fechaInicio: '2026-10-07',
+      },
+      {
+        etiqueta: 'Inicio de clases',
+        fechaInicio: '2026-10-26',
+      },
+    ],
+  },
+];
+
+const ADMISION_DIR = path.join(process.cwd(), 'src/content/admision');
+
+export async function seedAdmision() {
+  await fs.mkdir(ADMISION_DIR, { recursive: true });
+
+  const files = await fs.readdir(ADMISION_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(ADMISION_DIR, file));
+    }
+  }
+
+  for (const proceso of procesosAdmision) {
+    const filePath = path.join(ADMISION_DIR, `${proceso.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(proceso, null, 2));
+  }
+
+  console.log(`✅ ${procesosAdmision.length} procesos de admisión generados en src/content/admision/`);
+}

--- a/scripts/seeder/index.ts
+++ b/scripts/seeder/index.ts
@@ -4,6 +4,7 @@ import { seedAutoridades } from './autoridades';
 import { seedSustentaciones } from './sustentaciones';
 import { seedProgramas } from './programas';
 import { seedServicios } from './servicios';
+import { seedAdmision } from './admision';
 
 async function runSeeders() {
   console.log('🌱 Iniciando generación de datos (Seeders)...');
@@ -15,6 +16,7 @@ async function runSeeders() {
     await seedSustentaciones(15);
     await seedProgramas();
     await seedServicios();
+    await seedAdmision();
     
     console.log('✅ Todos los seeders se ejecutaron correctamente.');
   } catch (error) {

--- a/src/content/admision/adm-2026-I.json
+++ b/src/content/admision/adm-2026-I.json
@@ -1,0 +1,30 @@
+{
+  "id": "adm-2026-I",
+  "periodo": "2026-I",
+  "anio": 2026,
+  "fechaApertura": "2026-03-16",
+  "fechaCierre": "2026-04-30",
+  "fechasImportantes": [
+    {
+      "etiqueta": "Inscripciones",
+      "fechaInicio": "2026-03-16",
+      "fechaFin": "2026-04-30",
+      "descripcion": "Período de inscripciones para el proceso de admisión"
+    },
+    {
+      "etiqueta": "Examen de admisión",
+      "fechaInicio": "2026-05-09",
+      "descripcion": "Evaluación de conocimientos"
+    },
+    {
+      "etiqueta": "Resultados",
+      "fechaInicio": "2026-05-13",
+      "descripcion": "Publicación de resultados"
+    },
+    {
+      "etiqueta": "Inicio de clases",
+      "fechaInicio": "2026-06-01",
+      "descripcion": "Comienzo del semestre académico"
+    }
+  ]
+}

--- a/src/content/admision/adm-2026-II.json
+++ b/src/content/admision/adm-2026-II.json
@@ -1,0 +1,26 @@
+{
+  "id": "adm-2026-II",
+  "periodo": "2026-II",
+  "anio": 2026,
+  "fechaApertura": "2026-08-03",
+  "fechaCierre": "2026-09-18",
+  "fechasImportantes": [
+    {
+      "etiqueta": "Inscripciones",
+      "fechaInicio": "2026-08-03",
+      "fechaFin": "2026-09-18"
+    },
+    {
+      "etiqueta": "Examen de admisión",
+      "fechaInicio": "2026-10-03"
+    },
+    {
+      "etiqueta": "Resultados",
+      "fechaInicio": "2026-10-07"
+    },
+    {
+      "etiqueta": "Inicio de clases",
+      "fechaInicio": "2026-10-26"
+    }
+  ]
+}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -132,6 +132,24 @@ const serviciosCollection = defineCollection({
   }),
 });
 
+const admisionCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    periodo: z.string(),
+    anio: z.number(),
+    fechaApertura: z.string(),
+    fechaCierre: z.string(),
+    fechasImportantes: z.array(z.object({
+      etiqueta: z.string(),
+      fechaInicio: z.string(),
+      fechaFin: z.string().optional(),
+      descripcion: z.string().optional(),
+    })),
+    estadoOverride: z.enum(['abierta', 'cerrada', 'proximamente', 'en_evaluacion']).optional(),
+  }),
+});
+
 const estudiantesAccesosCollection = defineCollection({
   type: 'data',
   schema: z.object({
@@ -211,6 +229,7 @@ const estudiantesFaqCollection = defineCollection({
 });
 
 export const collections = {
+  admision: admisionCollection,
   estudiantes_accesos: estudiantesAccesosCollection,
   estudiantes_tramites: estudiantesTramitesCollection,
   estudiantes_documentos: estudiantesDocumentosCollection,

--- a/src/data/admision.ts
+++ b/src/data/admision.ts
@@ -1,65 +1,19 @@
+import { getCollection } from 'astro:content';
 import type { ProcesoAdmision, FechaImportanteAdmision, EstadoConvocatoria } from '@/types';
 
-// Procesos de admisión disponibles
-const procesosAdmision: ProcesoAdmision[] = [
-  {
-    id: 'adm-2026-I',
-    periodo: '2026-I',
-    anio: 2026,
-    fechaApertura: '2026-03-16',
-    fechaCierre: '2026-04-30',
-    fechasImportantes: [
-      { 
-        etiqueta: 'Inscripciones', 
-        fechaInicio: '2026-03-16', 
-        fechaFin: '2026-04-30',
-        descripcion: 'Período de inscripciones para el proceso de admisión'
-      },
-      { 
-        etiqueta: 'Examen de admisión', 
-        fechaInicio: '2026-05-09',
-        descripcion: 'Evaluación de conocimientos'
-      },
-      { 
-        etiqueta: 'Resultados', 
-        fechaInicio: '2026-05-13',
-        descripcion: 'Publicación de resultados'
-      },
-      { 
-        etiqueta: 'Inicio de clases', 
-        fechaInicio: '2026-06-01',
-        descripcion: 'Comienzo del semestre académico'
-      },
-    ],
-    // Sin estadoOverride - se calcula automáticamente
-  },
-  {
-    id: 'adm-2026-II',
-    periodo: '2026-II',
-    anio: 2026,
-    fechaApertura: '2026-08-03',
-    fechaCierre: '2026-09-18',
-    fechasImportantes: [
-      { 
-        etiqueta: 'Inscripciones', 
-        fechaInicio: '2026-08-03', 
-        fechaFin: '2026-09-18' 
-      },
-      { 
-        etiqueta: 'Examen de admisión', 
-        fechaInicio: '2026-10-03' 
-      },
-      { 
-        etiqueta: 'Resultados', 
-        fechaInicio: '2026-10-07' 
-      },
-      { 
-        etiqueta: 'Inicio de clases', 
-        fechaInicio: '2026-10-26' 
-      },
-    ],
-  },
-];
+async function fetchProcesosAdmision(): Promise<ProcesoAdmision[]> {
+  const collection = await getCollection('admision');
+
+  return collection
+    .map((entry) => ({
+      ...entry.data,
+      id: entry.data.id ?? entry.id,
+    }))
+    .sort(
+      (a, b) =>
+        new Date(a.fechaApertura).getTime() - new Date(b.fechaApertura).getTime(),
+    ) as ProcesoAdmision[];
+}
 
 /**
  * Calcula el estado de un proceso de admisión basado en las fechas o override manual
@@ -88,22 +42,27 @@ export const calcularEstadoProceso = (proceso: ProcesoAdmision): EstadoConvocato
 /**
  * Obtiene todos los procesos de admisión
  */
-export const getProcesosAdmision = (): ProcesoAdmision[] => {
+export const getProcesosAdmision = async (): Promise<ProcesoAdmision[]> => {
+  const procesosAdmision = await fetchProcesosAdmision();
   return [...procesosAdmision];
 };
 
 /**
  * Obtiene los procesos con convocatoria abierta
  */
-export const getProcesosActivos = (): ProcesoAdmision[] => {
+export const getProcesosActivos = async (): Promise<ProcesoAdmision[]> => {
+  const procesosAdmision = await fetchProcesosAdmision();
   return procesosAdmision.filter(p => calcularEstadoProceso(p) === 'abierta');
 };
 
 /**
  * Obtiene el proceso actual (primero activo, o el más próximo si no hay activos)
  */
-export const getProcesoActual = (): ProcesoAdmision | null => {
-  const activos = getProcesosActivos();
+export const getProcesoActual = async (): Promise<ProcesoAdmision | null> => {
+  const procesosAdmision = await fetchProcesosAdmision();
+  const activos = procesosAdmision.filter(
+    (p) => calcularEstadoProceso(p) === 'abierta',
+  );
   
   if (activos.length > 0) {
     return activos[0];
@@ -126,15 +85,16 @@ export const getProcesoActual = (): ProcesoAdmision | null => {
 /**
  * Verifica si hay al menos una convocatoria abierta
  */
-export const estaConvocatoriaAbierta = (): boolean => {
-  return getProcesosActivos().length > 0;
+export const estaConvocatoriaAbierta = async (): Promise<boolean> => {
+  const activos = await getProcesosActivos();
+  return activos.length > 0;
 };
 
 /**
  * Obtiene el estado del proceso actual
  */
-export const getEstadoProcesoActual = (): EstadoConvocatoria => {
-  const proceso = getProcesoActual();
+export const getEstadoProcesoActual = async (): Promise<EstadoConvocatoria> => {
+  const proceso = await getProcesoActual();
   if (!proceso) return 'cerrada';
   return calcularEstadoProceso(proceso);
 };

--- a/src/features/home/components/AdmissionCTA.astro
+++ b/src/features/home/components/AdmissionCTA.astro
@@ -11,9 +11,9 @@ import {
 import { contactoAdmision } from '@/data/contacto';
 import { ArrowRight, Calendar, FileText, Phone } from 'lucide-react';
 
-const proceso = getProcesoActual();
+const proceso = await getProcesoActual();
 const estado = proceso ? calcularEstadoProceso(proceso) : 'cerrada';
-const convocatoriaAbierta = estaConvocatoriaAbierta();
+const convocatoriaAbierta = await estaConvocatoriaAbierta();
 
 const badgeClass = convocatoriaAbierta
   ? 'bg-epg-navy text-white'


### PR DESCRIPTION
## Summary
- Migrates `src/data/admision.ts` from hardcoded arrays to Astro Content Collections using `getCollection('admision')`.
- Adds the `admision` Zod schema in `src/content/config.ts` and seeds collection data via `scripts/seeder/admision.ts`.
- Updates `AdmissionCTA.astro` to await async admision data functions while preserving existing behavior.

## Validation
- `pnpm tsc --noEmit`
- `pnpm run build`