### PR TITLE
refactor: migrate remaining data modules to content collections (#258)

### DIFF
--- a/scripts/seeder/busquedas-populares.ts
+++ b/scripts/seeder/busquedas-populares.ts
@@ -1,0 +1,52 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { BusquedaPopular } from '../../src/types';
+
+const busquedasPopulares: BusquedaPopular[] = [
+  {
+    id: 'gestion-publica',
+    label: 'Gestión Pública',
+    query: 'gestion publica',
+  },
+  {
+    id: 'derecho',
+    label: 'Derecho',
+    query: 'derecho',
+  },
+  {
+    id: 'educacion',
+    label: 'Educación',
+    query: 'educacion',
+  },
+  {
+    id: 'ambiental',
+    label: 'Ambiental',
+    query: 'ambiental',
+  },
+  {
+    id: 'salud',
+    label: 'Salud',
+    query: 'salud',
+  },
+];
+
+const BUSQUEDAS_DIR = path.join(process.cwd(), 'src/content/busquedas_populares');
+
+export async function seedBusquedasPopulares() {
+  await fs.mkdir(BUSQUEDAS_DIR, { recursive: true });
+
+  const files = await fs.readdir(BUSQUEDAS_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(BUSQUEDAS_DIR, file));
+    }
+  }
+
+  for (const busqueda of busquedasPopulares) {
+    const filePath = path.join(BUSQUEDAS_DIR, `${busqueda.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(busqueda, null, 2));
+  }
+
+  console.log(`✅ ${busquedasPopulares.length} búsquedas populares generadas en src/content/busquedas_populares/`);
+}

--- a/scripts/seeder/contacto.ts
+++ b/scripts/seeder/contacto.ts
@@ -1,0 +1,60 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { InfoContacto } from '../../src/types';
+
+const baseContacto: InfoContacto = {
+  direccion: 'Calle los Rosales S/N - Sta cuadra San Juan Bautista',
+  telefono: '+51987654320',
+  telefonoDisplay: '(065) 987-654-320',
+  email: 'postgrado@unap.edu.pe',
+  whatsapp: '+51987654320',
+  horarioAtencion: 'Lunes a Viernes: 7:00 a.m. - 2:00 p.m.',
+  coordenadas: {
+    lat: -3.7437,
+    lng: -73.2516,
+  },
+};
+
+const contactos: Array<InfoContacto & { id: string }> = [
+  {
+    id: 'general',
+    ...baseContacto,
+  },
+  {
+    id: 'admision',
+    ...baseContacto,
+    telefono: '+51987654321',
+    telefonoDisplay: '(065) 987-654-321',
+    email: 'admision@unap.edu.pe',
+    whatsapp: '+51987654321',
+  },
+  {
+    id: 'soporte',
+    ...baseContacto,
+    telefono: '+51987654322',
+    telefonoDisplay: '(065) 987-654-322',
+    email: 'soporte@unap.edu.pe',
+    whatsapp: '+51987654322',
+  },
+];
+
+const CONTACTO_DIR = path.join(process.cwd(), 'src/content/contacto');
+
+export async function seedContacto() {
+  await fs.mkdir(CONTACTO_DIR, { recursive: true });
+
+  const files = await fs.readdir(CONTACTO_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(CONTACTO_DIR, file));
+    }
+  }
+
+  for (const contacto of contactos) {
+    const filePath = path.join(CONTACTO_DIR, `${contacto.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(contacto, null, 2));
+  }
+
+  console.log(`✅ ${contactos.length} contactos generados en src/content/contacto/`);
+}

--- a/scripts/seeder/convocatorias.ts
+++ b/scripts/seeder/convocatorias.ts
@@ -1,0 +1,225 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { Convocatoria, FechaImportante } from '../../src/types';
+
+const convocatorias: Convocatoria[] = [
+  {
+    id: 'conv-001',
+    nombre: 'Proceso de Admisión 2026-I',
+    descripcion:
+      'Proceso de admisión para el primer semestre académico 2026. Incluye programas de maestría y doctorado en diversas especialidades.',
+    estado: 'abierta',
+    fechaInicio: '2026-03-16',
+    fechaFin: '2026-04-30',
+    fechaExamen: '2026-05-09',
+    fechaResultados: '2026-05-13',
+    requisitos: [
+      'Grado de Bachiller (para maestría) o Magíster (para doctorado)',
+      'DNI o Carnet de Extranjería vigente',
+      'Certificado de estudios original',
+      'Curriculum vitae documentado',
+      'Pago de derecho de inscripción: S/. 350.00',
+    ],
+    documentos: [
+      {
+        nombre: 'Copia de DNI',
+        descripcion: 'Copia legible del DNI vigente por ambos lados',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Grado académico',
+        descripcion: 'Copia legalizada del diploma de grado',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Certificado de estudios',
+        descripcion: 'Certificado de estudios original de pregrado/maestría',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Curriculum vitae',
+        descripcion: 'CV documentado con copias de constancias',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Foto tamaño pasaporte',
+        descripcion: '2 fotos a color fondo blanco',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Carta de presentación',
+        descripcion: 'Carta explicando motivación para el programa',
+        obligatorio: false,
+      },
+      {
+        nombre: 'Proyecto de investigación',
+        descripcion: 'Solo para doctorado: propuesta inicial de investigación',
+        obligatorio: false,
+      },
+    ],
+    programas: [
+      'mae-001',
+      'mae-002',
+      'mae-003',
+      'mae-004',
+      'mae-005',
+      'doc-001',
+      'doc-002',
+      'doc-003',
+    ],
+    slug: 'admision-2026-i',
+  },
+  {
+    id: 'conv-002',
+    nombre: 'Diplomados y Cursos de Actualización - Invierno 2026',
+    descripcion:
+      'Oferta de diplomados y cursos cortos de actualización profesional para el período de invierno 2026.',
+    estado: 'proximamente',
+    fechaInicio: '2026-06-15',
+    fechaFin: '2026-07-10',
+    requisitos: [
+      'Título profesional o bachiller universitario',
+      'DNI vigente',
+      'Acceso a computadora e internet (para cursos virtuales)',
+      'Pago de inscripción según programa',
+    ],
+    documentos: [
+      {
+        nombre: 'Copia de DNI',
+        descripcion: 'Copia legible del DNI',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Título o bachiller',
+        descripcion: 'Copia simple del grado académico',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Ficha de inscripción',
+        descripcion: 'Formulario de inscripción completado',
+        obligatorio: true,
+      },
+    ],
+    programas: ['dip-001', 'dip-002', 'dip-003', 'cur-001', 'cur-002'],
+    slug: 'diplomados-invierno-2026',
+  },
+  {
+    id: 'conv-003',
+    nombre: 'Proceso de Admisión 2026-II',
+    descripcion:
+      'Segundo proceso de admisión del año 2026 para programas de maestría y doctorado.',
+    estado: 'proximamente',
+    fechaInicio: '2026-08-03',
+    fechaFin: '2026-09-18',
+    fechaExamen: '2026-10-03',
+    fechaResultados: '2026-10-07',
+    requisitos: [
+      'Grado de Bachiller (para maestría) o Magíster (para doctorado)',
+      'DNI o Carnet de Extranjería vigente',
+      'Certificado de estudios original',
+      'Curriculum vitae documentado',
+      'Pago de derecho de inscripción: S/. 350.00',
+    ],
+    documentos: [
+      {
+        nombre: 'Copia de DNI',
+        descripcion: 'Copia legible del DNI vigente',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Grado académico',
+        descripcion: 'Copia legalizada del diploma',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Certificado de estudios',
+        descripcion: 'Certificado original',
+        obligatorio: true,
+      },
+      {
+        nombre: 'Curriculum vitae',
+        descripcion: 'CV documentado',
+        obligatorio: true,
+      },
+    ],
+    programas: ['mae-001', 'mae-002', 'mae-003', 'doc-001', 'doc-002'],
+    slug: 'admision-2026-ii',
+  },
+];
+
+const fechasImportantes: FechaImportante[] = [
+  {
+    fecha: '2026-03-16',
+    descripcion: 'Inicio de inscripciones - Admisión 2026-I',
+    tipo: 'inscripcion',
+  },
+  {
+    fecha: '2026-04-30',
+    descripcion: 'Cierre de inscripciones - Admisión 2026-I',
+    tipo: 'inscripcion',
+  },
+  {
+    fecha: '2026-05-09',
+    descripcion: 'Examen de admisión - Admisión 2026-I',
+    tipo: 'examen',
+  },
+  {
+    fecha: '2026-05-13',
+    descripcion: 'Publicación de resultados - Admisión 2026-I',
+    tipo: 'resultados',
+  },
+  {
+    fecha: '2026-05-18',
+    descripcion: 'Inicio de matrículas - Semestre 2026-I',
+    tipo: 'matricula',
+  },
+  {
+    fecha: '2026-05-27',
+    descripcion: 'Fin de matrículas regulares - Semestre 2026-I',
+    tipo: 'matricula',
+  },
+  {
+    fecha: '2026-06-01',
+    descripcion: 'Inicio de clases - Semestre 2026-I',
+    tipo: 'inicio_clases',
+  },
+];
+
+const CONVOCATORIAS_DIR = path.join(process.cwd(), 'src/content/convocatorias');
+const FECHAS_IMPORTANTES_DIR = path.join(
+  process.cwd(),
+  'src/content/fechas_importantes_admision',
+);
+
+async function cleanJsonFiles(directory: string) {
+  await fs.mkdir(directory, { recursive: true });
+
+  const files = await fs.readdir(directory);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(directory, file));
+    }
+  }
+}
+
+export async function seedConvocatorias() {
+  await cleanJsonFiles(CONVOCATORIAS_DIR);
+
+  for (const convocatoria of convocatorias) {
+    const filePath = path.join(CONVOCATORIAS_DIR, `${convocatoria.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(convocatoria, null, 2));
+  }
+
+  await cleanJsonFiles(FECHAS_IMPORTANTES_DIR);
+
+  for (const [index, fecha] of fechasImportantes.entries()) {
+    const filePath = path.join(FECHAS_IMPORTANTES_DIR, `fecha-${index + 1}.json`);
+    await fs.writeFile(filePath, JSON.stringify(fecha, null, 2));
+  }
+
+  console.log(`✅ ${convocatorias.length} convocatorias generadas en src/content/convocatorias/`);
+  console.log(
+    `✅ ${fechasImportantes.length} fechas importantes de admisión generadas en src/content/fechas_importantes_admision/`,
+  );
+}

--- a/scripts/seeder/documentos-institucionales.ts
+++ b/scripts/seeder/documentos-institucionales.ts
@@ -1,0 +1,89 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { Documento } from '../../src/types';
+
+const documentos: Documento[] = [
+  {
+    id: 'doc-reg-001',
+    nombre: 'Reglamento General de la Escuela de Postgrado',
+    descripcion:
+      'Normas generales que rigen el funcionamiento de la Escuela de Postgrado.',
+    url: '/documentos/reglamento-general-epg.pdf',
+    tipo: 'reglamento',
+    fechaActualizacion: '2024-03-15',
+  },
+  {
+    id: 'doc-reg-002',
+    nombre: 'Reglamento de Grados y Títulos',
+    descripcion:
+      'Procedimientos y requisitos para la obtención de grados de Magíster y Doctor.',
+    url: '/documentos/reglamento-grados-titulos.pdf',
+    tipo: 'reglamento',
+    fechaActualizacion: '2024-06-20',
+  },
+  {
+    id: 'doc-reg-003',
+    nombre: 'Reglamento de Admisión',
+    descripcion:
+      'Normas que regulan el proceso de admisión a los programas de postgrado.',
+    url: '/documentos/reglamento-admision.pdf',
+    tipo: 'reglamento',
+    fechaActualizacion: '2024-01-10',
+  },
+  {
+    id: 'doc-for-001',
+    nombre: 'Formato de Proyecto de Tesis',
+    descripcion: 'Modelo para la presentación del proyecto de tesis.',
+    url: '/documentos/formato-proyecto-tesis.docx',
+    tipo: 'formato',
+    fechaActualizacion: '2024-08-05',
+  },
+  {
+    id: 'doc-for-002',
+    nombre: 'Formato de Informe de Tesis',
+    descripcion: 'Estructura y formato para el informe final de tesis.',
+    url: '/documentos/formato-informe-tesis.docx',
+    tipo: 'formato',
+    fechaActualizacion: '2024-08-05',
+  },
+  {
+    id: 'doc-gui-001',
+    nombre: 'Guía de Elaboración de Tesis',
+    descripcion: 'Manual completo para la elaboración y sustentación de tesis.',
+    url: '/documentos/guia-elaboracion-tesis.pdf',
+    tipo: 'guia',
+    fechaActualizacion: '2024-07-12',
+  },
+  {
+    id: 'doc-man-001',
+    nombre: 'Manual de Usuario SIGAE',
+    descripcion:
+      'Instrucciones para el uso del Sistema de Gestión Académica.',
+    url: '/documentos/manual-sigae.pdf',
+    tipo: 'manual',
+    fechaActualizacion: '2024-02-28',
+  },
+];
+
+const DOCUMENTOS_DIR = path.join(process.cwd(), 'src/content/documentos_institucionales');
+
+export async function seedDocumentosInstitucionales() {
+  await fs.mkdir(DOCUMENTOS_DIR, { recursive: true });
+
+  const files = await fs.readdir(DOCUMENTOS_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(DOCUMENTOS_DIR, file));
+    }
+  }
+
+  for (const documento of documentos) {
+    const filePath = path.join(DOCUMENTOS_DIR, `${documento.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(documento, null, 2));
+  }
+
+  console.log(
+    `✅ ${documentos.length} documentos institucionales generados en src/content/documentos_institucionales/`,
+  );
+}

--- a/scripts/seeder/estadisticas.ts
+++ b/scripts/seeder/estadisticas.ts
@@ -1,0 +1,69 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { Estadistica } from '../../src/types';
+
+const estadisticasInstitucionales: Estadistica[] = [
+  {
+    id: 'trayectoria',
+    value: '35+',
+    label: 'Años de Trayectoria',
+    description: 'Formando profesionales desde 1990',
+    icon: 'Calendar',
+  },
+  {
+    id: 'egresados',
+    value: '2,500+',
+    label: 'Egresados',
+    description: 'Profesionales que lideran el cambio',
+    icon: 'Users',
+  },
+  {
+    id: 'maestrias',
+    value: '15+',
+    label: 'Maestrías',
+    description: 'Programas de especialización',
+    icon: 'GraduationCap',
+  },
+  {
+    id: 'doctorados',
+    value: '5',
+    label: 'Doctorados',
+    description: 'Investigación de alto nivel',
+    icon: 'Award',
+  },
+  {
+    id: 'docentes',
+    value: '120+',
+    label: 'Docentes',
+    description: 'Profesionales especializados',
+    icon: 'BookOpen',
+  },
+  {
+    id: 'satisfaccion',
+    value: '98%',
+    label: 'Satisfacción',
+    description: 'Estudiantes satisfechos',
+    icon: 'ThumbsUp',
+  },
+];
+
+const ESTADISTICAS_DIR = path.join(process.cwd(), 'src/content/estadisticas');
+
+export async function seedEstadisticas() {
+  await fs.mkdir(ESTADISTICAS_DIR, { recursive: true });
+
+  const files = await fs.readdir(ESTADISTICAS_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(ESTADISTICAS_DIR, file));
+    }
+  }
+
+  for (const estadistica of estadisticasInstitucionales) {
+    const filePath = path.join(ESTADISTICAS_DIR, `${estadistica.id}.json`);
+    await fs.writeFile(filePath, JSON.stringify(estadistica, null, 2));
+  }
+
+  console.log(`✅ ${estadisticasInstitucionales.length} estadísticas generadas en src/content/estadisticas/`);
+}

--- a/scripts/seeder/index.ts
+++ b/scripts/seeder/index.ts
@@ -5,6 +5,12 @@ import { seedSustentaciones } from './sustentaciones';
 import { seedProgramas } from './programas';
 import { seedServicios } from './servicios';
 import { seedAdmision } from './admision';
+import { seedContacto } from './contacto';
+import { seedBusquedasPopulares } from './busquedas-populares';
+import { seedEstadisticas } from './estadisticas';
+import { seedInfoInstitucional } from './info-institucional';
+import { seedDocumentosInstitucionales } from './documentos-institucionales';
+import { seedConvocatorias } from './convocatorias';
 
 async function runSeeders() {
   console.log('🌱 Iniciando generación de datos (Seeders)...');
@@ -17,6 +23,12 @@ async function runSeeders() {
     await seedProgramas();
     await seedServicios();
     await seedAdmision();
+    await seedContacto();
+    await seedBusquedasPopulares();
+    await seedEstadisticas();
+    await seedInfoInstitucional();
+    await seedDocumentosInstitucionales();
+    await seedConvocatorias();
     
     console.log('✅ Todos los seeders se ejecutaron correctamente.');
   } catch (error) {

--- a/scripts/seeder/info-institucional.ts
+++ b/scripts/seeder/info-institucional.ts
@@ -1,0 +1,50 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { InfoInstitucional } from '../../src/types';
+
+const infoInstitucional: InfoInstitucional & { id: string } = {
+  id: 'principal',
+  nombreCompleto:
+    'Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana',
+  nombreCorto: 'EPG-UNAP',
+  lema: 'Formando líderes para el desarrollo de la Amazonía',
+  historia: `La Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana fue creada en 1990, con la misión de formar profesionales de alto nivel académico comprometidos con el desarrollo sostenible de la región amazónica.
+
+A lo largo de más de tres décadas, hemos graduado a miles de profesionales que hoy ocupan cargos de liderazgo en instituciones públicas y privadas, contribuyendo significativamente al desarrollo de nuestra región y del país.
+
+Nuestra oferta académica ha evolucionado para responder a las demandas del mercado laboral y las necesidades de desarrollo regional, incorporando programas innovadores en áreas estratégicas como gestión pública, derecho, educación, salud pública y ciencias ambientales.`,
+  mision:
+    'Formar profesionales de postgrado con excelencia académica, competencias investigativas y compromiso ético, capaces de generar conocimiento y liderar procesos de transformación para el desarrollo sostenible de la Amazonía peruana.',
+  vision:
+    'Ser una Escuela de Postgrado líder en la formación de profesionales e investigadores de alto nivel en la Amazonía, reconocida nacional e internacionalmente por la calidad de sus programas, la producción científica de su comunidad académica y su contribución al desarrollo regional.',
+  valores: [
+    'Excelencia académica',
+    'Integridad y ética',
+    'Innovación e investigación',
+    'Responsabilidad social',
+    'Respeto a la diversidad',
+    'Compromiso con la Amazonía',
+  ],
+};
+
+const INFO_INSTITUCIONAL_DIR = path.join(
+  process.cwd(),
+  'src/content/info_institucional',
+);
+
+export async function seedInfoInstitucional() {
+  await fs.mkdir(INFO_INSTITUCIONAL_DIR, { recursive: true });
+
+  const files = await fs.readdir(INFO_INSTITUCIONAL_DIR);
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      await fs.unlink(path.join(INFO_INSTITUCIONAL_DIR, file));
+    }
+  }
+
+  const filePath = path.join(INFO_INSTITUCIONAL_DIR, 'principal.json');
+  await fs.writeFile(filePath, JSON.stringify(infoInstitucional, null, 2));
+
+  console.log('✅ Información institucional generada en src/content/info_institucional/');
+}

--- a/src/content/busquedas_populares/ambiental.json
+++ b/src/content/busquedas_populares/ambiental.json
@@ -1,0 +1,5 @@
+{
+  "id": "ambiental",
+  "label": "Ambiental",
+  "query": "ambiental"
+}

--- a/src/content/busquedas_populares/derecho.json
+++ b/src/content/busquedas_populares/derecho.json
@@ -1,0 +1,5 @@
+{
+  "id": "derecho",
+  "label": "Derecho",
+  "query": "derecho"
+}

--- a/src/content/busquedas_populares/educacion.json
+++ b/src/content/busquedas_populares/educacion.json
@@ -1,0 +1,5 @@
+{
+  "id": "educacion",
+  "label": "Educación",
+  "query": "educacion"
+}

--- a/src/content/busquedas_populares/gestion-publica.json
+++ b/src/content/busquedas_populares/gestion-publica.json
@@ -1,0 +1,5 @@
+{
+  "id": "gestion-publica",
+  "label": "Gestión Pública",
+  "query": "gestion publica"
+}

--- a/src/content/busquedas_populares/salud.json
+++ b/src/content/busquedas_populares/salud.json
@@ -1,0 +1,5 @@
+{
+  "id": "salud",
+  "label": "Salud",
+  "query": "salud"
+}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -150,6 +150,106 @@ const admisionCollection = defineCollection({
   }),
 });
 
+const contactoCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    direccion: z.string(),
+    telefono: z.string(),
+    telefonoDisplay: z.string(),
+    email: z.string().email(),
+    whatsapp: z.string().optional(),
+    horarioAtencion: z.string(),
+    coordenadas: z
+      .object({
+        lat: z.number(),
+        lng: z.number(),
+      })
+      .optional(),
+  }),
+});
+
+const busquedasPopularesCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    label: z.string(),
+    query: z.string(),
+    tipo: z.enum(['maestria', 'doctorado', 'diplomado', 'curso']).optional(),
+  }),
+});
+
+const estadisticasCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    value: z.string(),
+    label: z.string(),
+    description: z.string(),
+    icon: z.string(),
+  }),
+});
+
+const infoInstitucionalCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombreCompleto: z.string(),
+    nombreCorto: z.string(),
+    lema: z.string(),
+    historia: z.string(),
+    mision: z.string(),
+    vision: z.string(),
+    valores: z.array(z.string()),
+  }),
+});
+
+const documentosInstitucionalesCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string().optional(),
+    url: z.string(),
+    tipo: z.enum(['reglamento', 'formato', 'manual', 'guia']),
+    fechaActualizacion: z.string().optional(),
+  }),
+});
+
+const convocatoriasCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    nombre: z.string(),
+    descripcion: z.string(),
+    estado: z.enum(['abierta', 'cerrada', 'proximamente', 'en_evaluacion']),
+    fechaInicio: z.string(),
+    fechaFin: z.string(),
+    fechaExamen: z.string().optional(),
+    fechaResultados: z.string().optional(),
+    requisitos: z.array(z.string()),
+    documentos: z.array(
+      z.object({
+        nombre: z.string(),
+        descripcion: z.string(),
+        obligatorio: z.boolean(),
+      }),
+    ),
+    programas: z.array(z.string()),
+    slug: z.string(),
+  }),
+});
+
+const fechasImportantesAdmisionCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    id: z.string().optional(),
+    fecha: z.string(),
+    descripcion: z.string(),
+    tipo: z.enum(['inscripcion', 'examen', 'resultados', 'matricula', 'inicio_clases']),
+  }),
+});
+
 const estudiantesAccesosCollection = defineCollection({
   type: 'data',
   schema: z.object({
@@ -229,6 +329,13 @@ const estudiantesFaqCollection = defineCollection({
 });
 
 export const collections = {
+  contacto: contactoCollection,
+  busquedas_populares: busquedasPopularesCollection,
+  estadisticas: estadisticasCollection,
+  info_institucional: infoInstitucionalCollection,
+  documentos_institucionales: documentosInstitucionalesCollection,
+  convocatorias: convocatoriasCollection,
+  fechas_importantes_admision: fechasImportantesAdmisionCollection,
   admision: admisionCollection,
   estudiantes_accesos: estudiantesAccesosCollection,
   estudiantes_tramites: estudiantesTramitesCollection,

--- a/src/content/contacto/admision.json
+++ b/src/content/contacto/admision.json
@@ -1,0 +1,13 @@
+{
+  "id": "admision",
+  "direccion": "Calle los Rosales S/N - Sta cuadra San Juan Bautista",
+  "telefono": "+51987654321",
+  "telefonoDisplay": "(065) 987-654-321",
+  "email": "admision@unap.edu.pe",
+  "whatsapp": "+51987654321",
+  "horarioAtencion": "Lunes a Viernes: 7:00 a.m. - 2:00 p.m.",
+  "coordenadas": {
+    "lat": -3.7437,
+    "lng": -73.2516
+  }
+}

--- a/src/content/contacto/general.json
+++ b/src/content/contacto/general.json
@@ -1,0 +1,13 @@
+{
+  "id": "general",
+  "direccion": "Calle los Rosales S/N - Sta cuadra San Juan Bautista",
+  "telefono": "+51987654320",
+  "telefonoDisplay": "(065) 987-654-320",
+  "email": "postgrado@unap.edu.pe",
+  "whatsapp": "+51987654320",
+  "horarioAtencion": "Lunes a Viernes: 7:00 a.m. - 2:00 p.m.",
+  "coordenadas": {
+    "lat": -3.7437,
+    "lng": -73.2516
+  }
+}

--- a/src/content/contacto/soporte.json
+++ b/src/content/contacto/soporte.json
@@ -1,0 +1,13 @@
+{
+  "id": "soporte",
+  "direccion": "Calle los Rosales S/N - Sta cuadra San Juan Bautista",
+  "telefono": "+51987654322",
+  "telefonoDisplay": "(065) 987-654-322",
+  "email": "soporte@unap.edu.pe",
+  "whatsapp": "+51987654322",
+  "horarioAtencion": "Lunes a Viernes: 7:00 a.m. - 2:00 p.m.",
+  "coordenadas": {
+    "lat": -3.7437,
+    "lng": -73.2516
+  }
+}

--- a/src/content/convocatorias/conv-001.json
+++ b/src/content/convocatorias/conv-001.json
@@ -1,0 +1,65 @@
+{
+  "id": "conv-001",
+  "nombre": "Proceso de Admisión 2026-I",
+  "descripcion": "Proceso de admisión para el primer semestre académico 2026. Incluye programas de maestría y doctorado en diversas especialidades.",
+  "estado": "abierta",
+  "fechaInicio": "2026-03-16",
+  "fechaFin": "2026-04-30",
+  "fechaExamen": "2026-05-09",
+  "fechaResultados": "2026-05-13",
+  "requisitos": [
+    "Grado de Bachiller (para maestría) o Magíster (para doctorado)",
+    "DNI o Carnet de Extranjería vigente",
+    "Certificado de estudios original",
+    "Curriculum vitae documentado",
+    "Pago de derecho de inscripción: S/. 350.00"
+  ],
+  "documentos": [
+    {
+      "nombre": "Copia de DNI",
+      "descripcion": "Copia legible del DNI vigente por ambos lados",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Grado académico",
+      "descripcion": "Copia legalizada del diploma de grado",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Certificado de estudios",
+      "descripcion": "Certificado de estudios original de pregrado/maestría",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Curriculum vitae",
+      "descripcion": "CV documentado con copias de constancias",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Foto tamaño pasaporte",
+      "descripcion": "2 fotos a color fondo blanco",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Carta de presentación",
+      "descripcion": "Carta explicando motivación para el programa",
+      "obligatorio": false
+    },
+    {
+      "nombre": "Proyecto de investigación",
+      "descripcion": "Solo para doctorado: propuesta inicial de investigación",
+      "obligatorio": false
+    }
+  ],
+  "programas": [
+    "mae-001",
+    "mae-002",
+    "mae-003",
+    "mae-004",
+    "mae-005",
+    "doc-001",
+    "doc-002",
+    "doc-003"
+  ],
+  "slug": "admision-2026-i"
+}

--- a/src/content/convocatorias/conv-002.json
+++ b/src/content/convocatorias/conv-002.json
@@ -1,0 +1,39 @@
+{
+  "id": "conv-002",
+  "nombre": "Diplomados y Cursos de Actualización - Invierno 2026",
+  "descripcion": "Oferta de diplomados y cursos cortos de actualización profesional para el período de invierno 2026.",
+  "estado": "proximamente",
+  "fechaInicio": "2026-06-15",
+  "fechaFin": "2026-07-10",
+  "requisitos": [
+    "Título profesional o bachiller universitario",
+    "DNI vigente",
+    "Acceso a computadora e internet (para cursos virtuales)",
+    "Pago de inscripción según programa"
+  ],
+  "documentos": [
+    {
+      "nombre": "Copia de DNI",
+      "descripcion": "Copia legible del DNI",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Título o bachiller",
+      "descripcion": "Copia simple del grado académico",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Ficha de inscripción",
+      "descripcion": "Formulario de inscripción completado",
+      "obligatorio": true
+    }
+  ],
+  "programas": [
+    "dip-001",
+    "dip-002",
+    "dip-003",
+    "cur-001",
+    "cur-002"
+  ],
+  "slug": "diplomados-invierno-2026"
+}

--- a/src/content/convocatorias/conv-003.json
+++ b/src/content/convocatorias/conv-003.json
@@ -1,0 +1,47 @@
+{
+  "id": "conv-003",
+  "nombre": "Proceso de Admisión 2026-II",
+  "descripcion": "Segundo proceso de admisión del año 2026 para programas de maestría y doctorado.",
+  "estado": "proximamente",
+  "fechaInicio": "2026-08-03",
+  "fechaFin": "2026-09-18",
+  "fechaExamen": "2026-10-03",
+  "fechaResultados": "2026-10-07",
+  "requisitos": [
+    "Grado de Bachiller (para maestría) o Magíster (para doctorado)",
+    "DNI o Carnet de Extranjería vigente",
+    "Certificado de estudios original",
+    "Curriculum vitae documentado",
+    "Pago de derecho de inscripción: S/. 350.00"
+  ],
+  "documentos": [
+    {
+      "nombre": "Copia de DNI",
+      "descripcion": "Copia legible del DNI vigente",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Grado académico",
+      "descripcion": "Copia legalizada del diploma",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Certificado de estudios",
+      "descripcion": "Certificado original",
+      "obligatorio": true
+    },
+    {
+      "nombre": "Curriculum vitae",
+      "descripcion": "CV documentado",
+      "obligatorio": true
+    }
+  ],
+  "programas": [
+    "mae-001",
+    "mae-002",
+    "mae-003",
+    "doc-001",
+    "doc-002"
+  ],
+  "slug": "admision-2026-ii"
+}

--- a/src/content/documentos_institucionales/doc-for-001.json
+++ b/src/content/documentos_institucionales/doc-for-001.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-for-001",
+  "nombre": "Formato de Proyecto de Tesis",
+  "descripcion": "Modelo para la presentación del proyecto de tesis.",
+  "url": "/documentos/formato-proyecto-tesis.docx",
+  "tipo": "formato",
+  "fechaActualizacion": "2024-08-05"
+}

--- a/src/content/documentos_institucionales/doc-for-002.json
+++ b/src/content/documentos_institucionales/doc-for-002.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-for-002",
+  "nombre": "Formato de Informe de Tesis",
+  "descripcion": "Estructura y formato para el informe final de tesis.",
+  "url": "/documentos/formato-informe-tesis.docx",
+  "tipo": "formato",
+  "fechaActualizacion": "2024-08-05"
+}

--- a/src/content/documentos_institucionales/doc-gui-001.json
+++ b/src/content/documentos_institucionales/doc-gui-001.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-gui-001",
+  "nombre": "Guía de Elaboración de Tesis",
+  "descripcion": "Manual completo para la elaboración y sustentación de tesis.",
+  "url": "/documentos/guia-elaboracion-tesis.pdf",
+  "tipo": "guia",
+  "fechaActualizacion": "2024-07-12"
+}

--- a/src/content/documentos_institucionales/doc-man-001.json
+++ b/src/content/documentos_institucionales/doc-man-001.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-man-001",
+  "nombre": "Manual de Usuario SIGAE",
+  "descripcion": "Instrucciones para el uso del Sistema de Gestión Académica.",
+  "url": "/documentos/manual-sigae.pdf",
+  "tipo": "manual",
+  "fechaActualizacion": "2024-02-28"
+}

--- a/src/content/documentos_institucionales/doc-reg-001.json
+++ b/src/content/documentos_institucionales/doc-reg-001.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-reg-001",
+  "nombre": "Reglamento General de la Escuela de Postgrado",
+  "descripcion": "Normas generales que rigen el funcionamiento de la Escuela de Postgrado.",
+  "url": "/documentos/reglamento-general-epg.pdf",
+  "tipo": "reglamento",
+  "fechaActualizacion": "2024-03-15"
+}

--- a/src/content/documentos_institucionales/doc-reg-002.json
+++ b/src/content/documentos_institucionales/doc-reg-002.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-reg-002",
+  "nombre": "Reglamento de Grados y Títulos",
+  "descripcion": "Procedimientos y requisitos para la obtención de grados de Magíster y Doctor.",
+  "url": "/documentos/reglamento-grados-titulos.pdf",
+  "tipo": "reglamento",
+  "fechaActualizacion": "2024-06-20"
+}

--- a/src/content/documentos_institucionales/doc-reg-003.json
+++ b/src/content/documentos_institucionales/doc-reg-003.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-reg-003",
+  "nombre": "Reglamento de Admisión",
+  "descripcion": "Normas que regulan el proceso de admisión a los programas de postgrado.",
+  "url": "/documentos/reglamento-admision.pdf",
+  "tipo": "reglamento",
+  "fechaActualizacion": "2024-01-10"
+}

--- a/src/content/estadisticas/docentes.json
+++ b/src/content/estadisticas/docentes.json
@@ -1,0 +1,7 @@
+{
+  "id": "docentes",
+  "value": "120+",
+  "label": "Docentes",
+  "description": "Profesionales especializados",
+  "icon": "BookOpen"
+}

--- a/src/content/estadisticas/doctorados.json
+++ b/src/content/estadisticas/doctorados.json
@@ -1,0 +1,7 @@
+{
+  "id": "doctorados",
+  "value": "5",
+  "label": "Doctorados",
+  "description": "Investigación de alto nivel",
+  "icon": "Award"
+}

--- a/src/content/estadisticas/egresados.json
+++ b/src/content/estadisticas/egresados.json
@@ -1,0 +1,7 @@
+{
+  "id": "egresados",
+  "value": "2,500+",
+  "label": "Egresados",
+  "description": "Profesionales que lideran el cambio",
+  "icon": "Users"
+}

--- a/src/content/estadisticas/maestrias.json
+++ b/src/content/estadisticas/maestrias.json
@@ -1,0 +1,7 @@
+{
+  "id": "maestrias",
+  "value": "15+",
+  "label": "Maestrías",
+  "description": "Programas de especialización",
+  "icon": "GraduationCap"
+}

--- a/src/content/estadisticas/satisfaccion.json
+++ b/src/content/estadisticas/satisfaccion.json
@@ -1,0 +1,7 @@
+{
+  "id": "satisfaccion",
+  "value": "98%",
+  "label": "Satisfacción",
+  "description": "Estudiantes satisfechos",
+  "icon": "ThumbsUp"
+}

--- a/src/content/estadisticas/trayectoria.json
+++ b/src/content/estadisticas/trayectoria.json
@@ -1,0 +1,7 @@
+{
+  "id": "trayectoria",
+  "value": "35+",
+  "label": "Años de Trayectoria",
+  "description": "Formando profesionales desde 1990",
+  "icon": "Calendar"
+}

--- a/src/content/fechas_importantes_admision/fecha-1.json
+++ b/src/content/fechas_importantes_admision/fecha-1.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-03-16",
+  "descripcion": "Inicio de inscripciones - Admisión 2026-I",
+  "tipo": "inscripcion"
+}

--- a/src/content/fechas_importantes_admision/fecha-2.json
+++ b/src/content/fechas_importantes_admision/fecha-2.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-04-30",
+  "descripcion": "Cierre de inscripciones - Admisión 2026-I",
+  "tipo": "inscripcion"
+}

--- a/src/content/fechas_importantes_admision/fecha-3.json
+++ b/src/content/fechas_importantes_admision/fecha-3.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-05-09",
+  "descripcion": "Examen de admisión - Admisión 2026-I",
+  "tipo": "examen"
+}

--- a/src/content/fechas_importantes_admision/fecha-4.json
+++ b/src/content/fechas_importantes_admision/fecha-4.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-05-13",
+  "descripcion": "Publicación de resultados - Admisión 2026-I",
+  "tipo": "resultados"
+}

--- a/src/content/fechas_importantes_admision/fecha-5.json
+++ b/src/content/fechas_importantes_admision/fecha-5.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-05-18",
+  "descripcion": "Inicio de matrículas - Semestre 2026-I",
+  "tipo": "matricula"
+}

--- a/src/content/fechas_importantes_admision/fecha-6.json
+++ b/src/content/fechas_importantes_admision/fecha-6.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-05-27",
+  "descripcion": "Fin de matrículas regulares - Semestre 2026-I",
+  "tipo": "matricula"
+}

--- a/src/content/fechas_importantes_admision/fecha-7.json
+++ b/src/content/fechas_importantes_admision/fecha-7.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2026-06-01",
+  "descripcion": "Inicio de clases - Semestre 2026-I",
+  "tipo": "inicio_clases"
+}

--- a/src/content/info_institucional/principal.json
+++ b/src/content/info_institucional/principal.json
@@ -1,0 +1,17 @@
+{
+  "id": "principal",
+  "nombreCompleto": "Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana",
+  "nombreCorto": "EPG-UNAP",
+  "lema": "Formando líderes para el desarrollo de la Amazonía",
+  "historia": "La Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana fue creada en 1990, con la misión de formar profesionales de alto nivel académico comprometidos con el desarrollo sostenible de la región amazónica.\n\nA lo largo de más de tres décadas, hemos graduado a miles de profesionales que hoy ocupan cargos de liderazgo en instituciones públicas y privadas, contribuyendo significativamente al desarrollo de nuestra región y del país.\n\nNuestra oferta académica ha evolucionado para responder a las demandas del mercado laboral y las necesidades de desarrollo regional, incorporando programas innovadores en áreas estratégicas como gestión pública, derecho, educación, salud pública y ciencias ambientales.",
+  "mision": "Formar profesionales de postgrado con excelencia académica, competencias investigativas y compromiso ético, capaces de generar conocimiento y liderar procesos de transformación para el desarrollo sostenible de la Amazonía peruana.",
+  "vision": "Ser una Escuela de Postgrado líder en la formación de profesionales e investigadores de alto nivel en la Amazonía, reconocida nacional e internacionalmente por la calidad de sus programas, la producción científica de su comunidad académica y su contribución al desarrollo regional.",
+  "valores": [
+    "Excelencia académica",
+    "Integridad y ética",
+    "Innovación e investigación",
+    "Responsabilidad social",
+    "Respeto a la diversidad",
+    "Compromiso con la Amazonía"
+  ]
+}

--- a/src/data/busquedas-populares.ts
+++ b/src/data/busquedas-populares.ts
@@ -1,4 +1,6 @@
+import { getCollection } from 'astro:content';
 import type { BusquedaPopular } from '@/types';
+export { getBusquedaUrl } from '@/lib/busquedas-helpers';
 
 /**
  * Búsquedas populares para el home
@@ -11,47 +13,8 @@ import type { BusquedaPopular } from '@/types';
  * - Query: Parámetro de búsqueda (se codifica automáticamente en la URL)
  * - Tipo: (Opcional) Filtrar resultados por tipo de programa
  */
-export const busquedasPopulares: BusquedaPopular[] = [
-  {
-    id: 'gestion-publica',
-    label: 'Gestión Pública',
-    query: 'gestion publica',
-  },
-  {
-    id: 'derecho',
-    label: 'Derecho',
-    query: 'derecho',
-  },
-  {
-    id: 'educacion',
-    label: 'Educación',
-    query: 'educacion',
-  },
-  {
-    id: 'ambiental',
-    label: 'Ambiental',
-    query: 'ambiental',
-  },
-  {
-    id: 'salud',
-    label: 'Salud',
-    query: 'salud',
-  },
-];
-
-/**
- * Construye la URL de búsqueda con los parámetros apropiados
- * 
- * @param busqueda - Objeto BusquedaPopular
- * @returns URL completa para la búsqueda
- */
-export function getBusquedaUrl(busqueda: BusquedaPopular): string {
-  const params = new URLSearchParams();
-  params.set('q', busqueda.query);
-  
-  if (busqueda.tipo) {
-    params.set('tipo', busqueda.tipo);
-  }
-  
-  return `/programas?${params.toString()}`;
+export async function getBusquedasPopulares(): Promise<BusquedaPopular[]> {
+  const collection = await getCollection('busquedas_populares');
+  return collection.map((entry) => ({ ...entry.data, id: entry.data.id ?? entry.id })) as BusquedaPopular[];
 }
+

--- a/src/data/contacto.ts
+++ b/src/data/contacto.ts
@@ -1,62 +1,30 @@
+import { getEntry } from 'astro:content';
 import type { InfoContacto } from '@/types';
+export {
+  getEmailHref,
+  getTelefonoHref,
+  getWhatsappHref,
+} from '@/lib/contact-helpers';
 
-/**
- * Información de contacto general de la EPG
- */
-export const contactoGeneral: InfoContacto = {
-  direccion: 'Calle los Rosales S/N - Sta cuadra San Juan Bautista',
-  telefono: '+51987654320',
-  telefonoDisplay: '(065) 987-654-320',
-  email: 'postgrado@unap.edu.pe',
-  whatsapp: '+51987654320',
-  horarioAtencion: 'Lunes a Viernes: 7:00 a.m. - 2:00 p.m.',
-  coordenadas: {
-    lat: -3.7437,
-    lng: -73.2516,
-  },
-};
+async function getContactoById(id: string): Promise<InfoContacto> {
+  const entry = await getEntry('contacto', id);
+  if (!entry) {
+    throw new Error(`No se encontró el contacto '${id}' en la colección`);
+  }
 
-/**
- * Información de contacto específica para admisión
- */
-export const contactoAdmision: InfoContacto = {
-  ...contactoGeneral,
-  telefono: '+51987654321',
-  telefonoDisplay: '(065) 987-654-321',
-  email: 'admision@unap.edu.pe',
-  whatsapp: '+51987654321',
-};
+  return {
+    ...entry.data,
+  } as InfoContacto;
+}
 
-/**
- * Información de contacto para soporte técnico
- */
-export const contactoSoporte: InfoContacto = {
-  ...contactoGeneral,
-  telefono: '+51987654322',
-  telefonoDisplay: '(065) 987-654-322',
-  email: 'soporte@unap.edu.pe',
-  whatsapp: '+51987654322',
-};
+export async function getContactoGeneral(): Promise<InfoContacto> {
+  return getContactoById('general');
+}
 
-/**
- * Helper para obtener el href de teléfono
- */
-export const getTelefonoHref = (telefono: string): string => {
-  return `tel:${telefono}`;
-};
+export async function getContactoAdmision(): Promise<InfoContacto> {
+  return getContactoById('admision');
+}
 
-/**
- * Helper para obtener el href de email
- */
-export const getEmailHref = (email: string): string => {
-  return `mailto:${email}`;
-};
-
-/**
- * Helper para obtener el link de WhatsApp
- */
-export const getWhatsappHref = (whatsapp: string, mensaje?: string): string => {
-  const numero = whatsapp.replace(/\D/g, ''); // Remover caracteres no numéricos
-  const texto = mensaje ? `?text=${encodeURIComponent(mensaje)}` : '';
-  return `https://wa.me/${numero}${texto}`;
-};
+export async function getContactoSoporte(): Promise<InfoContacto> {
+  return getContactoById('soporte');
+}

--- a/src/data/convocatorias.ts
+++ b/src/data/convocatorias.ts
@@ -1,186 +1,54 @@
+import { getCollection, getEntry } from 'astro:content';
 import type { Convocatoria, FechaImportante } from '@/types';
 
-export const convocatorias: Convocatoria[] = [
-  {
-    id: 'conv-001',
-    nombre: 'Proceso de Admisión 2026-I',
-    descripcion: 'Proceso de admisión para el primer semestre académico 2026. Incluye programas de maestría y doctorado en diversas especialidades.',
-    estado: 'abierta',
-    fechaInicio: '2026-03-16',
-    fechaFin: '2026-04-30',
-    fechaExamen: '2026-05-09',
-    fechaResultados: '2026-05-13',
-    requisitos: [
-      'Grado de Bachiller (para maestría) o Magíster (para doctorado)',
-      'DNI o Carnet de Extranjería vigente',
-      'Certificado de estudios original',
-      'Curriculum vitae documentado',
-      'Pago de derecho de inscripción: S/. 350.00',
-    ],
-    documentos: [
-      {
-        nombre: 'Copia de DNI',
-        descripcion: 'Copia legible del DNI vigente por ambos lados',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Grado académico',
-        descripcion: 'Copia legalizada del diploma de grado',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Certificado de estudios',
-        descripcion: 'Certificado de estudios original de pregrado/maestría',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Curriculum vitae',
-        descripcion: 'CV documentado con copias de constancias',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Foto tamaño pasaporte',
-        descripcion: '2 fotos a color fondo blanco',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Carta de presentación',
-        descripcion: 'Carta explicando motivación para el programa',
-        obligatorio: false,
-      },
-      {
-        nombre: 'Proyecto de investigación',
-        descripcion: 'Solo para doctorado: propuesta inicial de investigación',
-        obligatorio: false,
-      },
-    ],
-    programas: ['mae-001', 'mae-002', 'mae-003', 'mae-004', 'mae-005', 'doc-001', 'doc-002', 'doc-003'],
-    slug: 'admision-2026-i',
-  },
-  {
-    id: 'conv-002',
-    nombre: 'Diplomados y Cursos de Actualización - Invierno 2026',
-    descripcion: 'Oferta de diplomados y cursos cortos de actualización profesional para el período de invierno 2026.',
-    estado: 'proximamente',
-    fechaInicio: '2026-06-15',
-    fechaFin: '2026-07-10',
-    requisitos: [
-      'Título profesional o bachiller universitario',
-      'DNI vigente',
-      'Acceso a computadora e internet (para cursos virtuales)',
-      'Pago de inscripción según programa',
-    ],
-    documentos: [
-      {
-        nombre: 'Copia de DNI',
-        descripcion: 'Copia legible del DNI',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Título o bachiller',
-        descripcion: 'Copia simple del grado académico',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Ficha de inscripción',
-        descripcion: 'Formulario de inscripción completado',
-        obligatorio: true,
-      },
-    ],
-    programas: ['dip-001', 'dip-002', 'dip-003', 'cur-001', 'cur-002'],
-    slug: 'diplomados-invierno-2026',
-  },
-  {
-    id: 'conv-003',
-    nombre: 'Proceso de Admisión 2026-II',
-    descripcion: 'Segundo proceso de admisión del año 2026 para programas de maestría y doctorado.',
-    estado: 'proximamente',
-    fechaInicio: '2026-08-03',
-    fechaFin: '2026-09-18',
-    fechaExamen: '2026-10-03',
-    fechaResultados: '2026-10-07',
-    requisitos: [
-      'Grado de Bachiller (para maestría) o Magíster (para doctorado)',
-      'DNI o Carnet de Extranjería vigente',
-      'Certificado de estudios original',
-      'Curriculum vitae documentado',
-      'Pago de derecho de inscripción: S/. 350.00',
-    ],
-    documentos: [
-      {
-        nombre: 'Copia de DNI',
-        descripcion: 'Copia legible del DNI vigente',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Grado académico',
-        descripcion: 'Copia legalizada del diploma',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Certificado de estudios',
-        descripcion: 'Certificado original',
-        obligatorio: true,
-      },
-      {
-        nombre: 'Curriculum vitae',
-        descripcion: 'CV documentado',
-        obligatorio: true,
-      },
-    ],
-    programas: ['mae-001', 'mae-002', 'mae-003', 'doc-001', 'doc-002'],
-    slug: 'admision-2026-ii',
-  },
-];
+export async function getConvocatorias(): Promise<Convocatoria[]> {
+  const collection = await getCollection('convocatorias');
 
-export const fechasImportantes: FechaImportante[] = [
-  // Proceso 2026-I
-  {
-    fecha: '2026-03-16',
-    descripcion: 'Inicio de inscripciones - Admisión 2026-I',
-    tipo: 'inscripcion',
-  },
-  {
-    fecha: '2026-04-30',
-    descripcion: 'Cierre de inscripciones - Admisión 2026-I',
-    tipo: 'inscripcion',
-  },
-  {
-    fecha: '2026-05-09',
-    descripcion: 'Examen de admisión - Admisión 2026-I',
-    tipo: 'examen',
-  },
-  {
-    fecha: '2026-05-13',
-    descripcion: 'Publicación de resultados - Admisión 2026-I',
-    tipo: 'resultados',
-  },
-  {
-    fecha: '2026-05-18',
-    descripcion: 'Inicio de matrículas - Semestre 2026-I',
-    tipo: 'matricula',
-  },
-  {
-    fecha: '2026-05-27',
-    descripcion: 'Fin de matrículas regulares - Semestre 2026-I',
-    tipo: 'matricula',
-  },
-  {
-    fecha: '2026-06-01',
-    descripcion: 'Inicio de clases - Semestre 2026-I',
-    tipo: 'inicio_clases',
-  },
-];
+  return collection.map((entry) => ({
+    ...entry.data,
+    id: entry.data.id ?? entry.id,
+  })) as Convocatoria[];
+}
 
-// Helpers
-export const getConvocatoriaById = (id: string) => convocatorias.find(c => c.id === id);
-export const getConvocatoriaBySlug = (slug: string) => convocatorias.find(c => c.slug === slug);
-export const getConvocatoriasAbiertas = () => convocatorias.filter(c => c.estado === 'abierta');
-export const getConvocatoriasProximas = () => convocatorias.filter(c => c.estado === 'proximamente');
-export const getFechasProximas = (cantidad: number = 5) => {
+export async function getFechasImportantesAdmision(): Promise<FechaImportante[]> {
+  const collection = await getCollection('fechas_importantes_admision');
+
+  return collection.map((entry) => ({
+    ...entry.data,
+    id: entry.data.id ?? entry.id,
+  })) as FechaImportante[];
+}
+
+export async function getConvocatoriaById(id: string): Promise<Convocatoria | undefined> {
+  const entry = await getEntry('convocatorias', id);
+  if (!entry) return undefined;
+  return {
+    ...entry.data,
+    id: entry.data.id ?? entry.id,
+  } as Convocatoria;
+}
+
+export async function getConvocatoriaBySlug(slug: string): Promise<Convocatoria | undefined> {
+  const convocatorias = await getConvocatorias();
+  return convocatorias.find((c) => c.slug === slug);
+}
+
+export async function getConvocatoriasAbiertas(): Promise<Convocatoria[]> {
+  const convocatorias = await getConvocatorias();
+  return convocatorias.filter((c) => c.estado === 'abierta');
+}
+
+export async function getConvocatoriasProximas(): Promise<Convocatoria[]> {
+  const convocatorias = await getConvocatorias();
+  return convocatorias.filter((c) => c.estado === 'proximamente');
+}
+
+export async function getFechasProximas(cantidad: number = 5): Promise<FechaImportante[]> {
   const hoy = new Date();
+  const fechasImportantes = await getFechasImportantesAdmision();
+
   return fechasImportantes
-    .filter(f => new Date(f.fecha) >= hoy)
+    .filter((f) => new Date(f.fecha) >= hoy)
     .sort((a, b) => new Date(a.fecha).getTime() - new Date(b.fecha).getTime())
     .slice(0, cantidad);
-};
+}

--- a/src/data/estadisticas.ts
+++ b/src/data/estadisticas.ts
@@ -1,50 +1,11 @@
+import { getCollection } from 'astro:content';
 import type { Estadistica } from '@/types';
 
 /**
  * Estadísticas institucionales de la EPG UNAP
  * Estos datos se muestran en la sección de estadísticas del Home
  */
-export const estadisticasInstitucionales: Estadistica[] = [
-  {
-    id: 'trayectoria',
-    value: '35+',
-    label: 'Años de Trayectoria',
-    description: 'Formando profesionales desde 1990',
-    icon: 'Calendar',
-  },
-  {
-    id: 'egresados',
-    value: '2,500+',
-    label: 'Egresados',
-    description: 'Profesionales que lideran el cambio',
-    icon: 'Users',
-  },
-  {
-    id: 'maestrias',
-    value: '15+',
-    label: 'Maestrías',
-    description: 'Programas de especialización',
-    icon: 'GraduationCap',
-  },
-  {
-    id: 'doctorados',
-    value: '5',
-    label: 'Doctorados',
-    description: 'Investigación de alto nivel',
-    icon: 'Award',
-  },
-  {
-    id: 'docentes',
-    value: '120+',
-    label: 'Docentes',
-    description: 'Profesionales especializados',
-    icon: 'BookOpen',
-  },
-  {
-    id: 'satisfaccion',
-    value: '98%',
-    label: 'Satisfacción',
-    description: 'Estudiantes satisfechos',
-    icon: 'ThumbsUp',
-  },
-];
+export async function getEstadisticasInstitucionales(): Promise<Estadistica[]> {
+  const collection = await getCollection('estadisticas');
+  return collection.map((entry) => ({ ...entry.data, id: entry.data.id ?? entry.id })) as Estadistica[];
+}

--- a/src/data/institucional.ts
+++ b/src/data/institucional.ts
@@ -1,266 +1,47 @@
-import type { RedSocial, Documento, ProcesoEstudiantil, Sustentacion } from '@/types';
-import { contactoGeneral } from './contacto';
-import { estadisticasInstitucionales } from './estadisticas';
+import { getCollection, getEntry } from 'astro:content';
+import type { Documento, InfoInstitucional } from '@/types';
 
-// --- INFORMACIÓN DE CONTACTO ---
-// Re-exportar desde contacto.ts para mantener compatibilidad
-export const infoContacto = contactoGeneral;
+export async function getInfoInstitucional(): Promise<InfoInstitucional> {
+  const entry = await getEntry('info_institucional', 'principal');
 
-// Re-exportar estadísticas desde archivo centralizado
-export { estadisticasInstitucionales as estadisticas } from './estadisticas';
+  if (!entry) {
+    throw new Error("No se encontró 'info_institucional/principal'");
+  }
 
-// --- REDES SOCIALES ---
-export const redesSociales: RedSocial[] = [
-  {
-    nombre: 'Facebook',
-    url: 'https://facebook.com/epgunap',
-    icono: 'Facebook',
-  },
-  {
-    nombre: 'Instagram',
-    url: 'https://instagram.com/epgunap',
-    icono: 'Instagram',
-  },
-  {
-    nombre: 'YouTube',
-    url: 'https://youtube.com/@epgunap',
-    icono: 'Youtube',
-  },
-  {
-    nombre: 'LinkedIn',
-    url: 'https://linkedin.com/company/epgunap',
-    icono: 'Linkedin',
-  },
-  {
-    nombre: 'X (Twitter)',
-    url: 'https://twitter.com/epgunap',
-    icono: 'Twitter',
-  },
-];
+  return {
+    ...entry.data,
+    id: entry.data.id ?? entry.id,
+  } as InfoInstitucional;
+}
 
-// --- REDES SOCIALES ---
-export const documentos: Documento[] = [
-  {
-    id: 'doc-reg-001',
-    nombre: 'Reglamento General de la Escuela de Postgrado',
-    descripcion: 'Normas generales que rigen el funcionamiento de la Escuela de Postgrado.',
-    url: '/documentos/reglamento-general-epg.pdf',
-    tipo: 'reglamento',
-    fechaActualizacion: '2024-03-15',
-  },
-  {
-    id: 'doc-reg-002',
-    nombre: 'Reglamento de Grados y Títulos',
-    descripcion: 'Procedimientos y requisitos para la obtención de grados de Magíster y Doctor.',
-    url: '/documentos/reglamento-grados-titulos.pdf',
-    tipo: 'reglamento',
-    fechaActualizacion: '2024-06-20',
-  },
-  {
-    id: 'doc-reg-003',
-    nombre: 'Reglamento de Admisión',
-    descripcion: 'Normas que regulan el proceso de admisión a los programas de postgrado.',
-    url: '/documentos/reglamento-admision.pdf',
-    tipo: 'reglamento',
-    fechaActualizacion: '2024-01-10',
-  },
-  {
-    id: 'doc-for-001',
-    nombre: 'Formato de Proyecto de Tesis',
-    descripcion: 'Modelo para la presentación del proyecto de tesis.',
-    url: '/documentos/formato-proyecto-tesis.docx',
-    tipo: 'formato',
-    fechaActualizacion: '2024-08-05',
-  },
-  {
-    id: 'doc-for-002',
-    nombre: 'Formato de Informe de Tesis',
-    descripcion: 'Estructura y formato para el informe final de tesis.',
-    url: '/documentos/formato-informe-tesis.docx',
-    tipo: 'formato',
-    fechaActualizacion: '2024-08-05',
-  },
-  {
-    id: 'doc-gui-001',
-    nombre: 'Guía de Elaboración de Tesis',
-    descripcion: 'Manual completo para la elaboración y sustentación de tesis.',
-    url: '/documentos/guia-elaboracion-tesis.pdf',
-    tipo: 'guia',
-    fechaActualizacion: '2024-07-12',
-  },
-  {
-    id: 'doc-man-001',
-    nombre: 'Manual de Usuario SIGAE',
-    descripcion: 'Instrucciones para el uso del Sistema de Gestión Académica.',
-    url: '/documentos/manual-sigae.pdf',
-    tipo: 'manual',
-    fechaActualizacion: '2024-02-28',
-  },
-];
+export async function getDocumentosInstitucionales(): Promise<Documento[]> {
+  const collection = await getCollection('documentos_institucionales');
 
-// --- PROCESOS ESTUDIANTILES ---
-export const procesosEstudiantiles: ProcesoEstudiantil[] = [
-  {
-    id: 'proc-001',
-    nombre: 'Matrícula',
-    descripcion: 'Proceso de inscripción a las asignaturas del semestre académico.',
-    icono: 'ClipboardCheck',
-    slug: 'matricula',
-    requisitos: [
-      'Estar admitido en un programa de postgrado',
-      'No tener deudas pendientes',
-      'Pago de derechos de matrícula',
-    ],
-    pasos: [
-      'Verificar calendario de matrícula',
-      'Acceder al SIGAE con credenciales',
-      'Seleccionar asignaturas disponibles',
-      'Confirmar matrícula',
-      'Realizar pago de derechos',
-      'Imprimir constancia de matrícula',
-    ],
-  },
-  {
-    id: 'proc-002',
-    nombre: 'Trámite de Grado',
-    descripcion: 'Proceso para obtener el grado académico de Magíster o Doctor.',
-    icono: 'Award',
-    slug: 'tramite-grado',
-    requisitos: [
-      'Haber aprobado todas las asignaturas del plan de estudios',
-      'Tesis aprobada por jurado evaluador',
-      'Sustentación pública aprobada',
-      'No tener deudas con la universidad',
-    ],
-    pasos: [
-      'Solicitar expedito en mesa de partes',
-      'Pago de derechos de grado',
-      'Presentar documentos requeridos',
-      'Esperar resolución de consejo',
-      'Asistir a ceremonia de colación',
-    ],
-  },
-  {
-    id: 'proc-003',
-    nombre: 'Cambio de Programa',
-    descripcion: 'Procedimiento para trasladarse a otro programa de postgrado.',
-    icono: 'RefreshCw',
-    slug: 'cambio-programa',
-    requisitos: [
-      'Haber aprobado al menos un semestre',
-      'Promedio ponderado mínimo de 14.0',
-      'Vacante disponible en el programa destino',
-    ],
-    pasos: [
-      'Presentar solicitud en mesa de partes',
-      'Adjuntar expediente académico',
-      'Evaluación por coordinación del programa',
-      'Resolución de aprobación/rechazo',
-    ],
-  },
-  {
-    id: 'proc-004',
-    nombre: 'Licencia de Estudios',
-    descripcion: 'Solicitud de suspensión temporal de estudios.',
-    icono: 'PauseCircle',
-    slug: 'licencia-estudios',
-    requisitos: [
-      'Justificación documentada',
-      'No exceder el límite de licencias permitidas',
-      'No tener deudas pendientes',
-    ],
-    pasos: [
-      'Presentar solicitud con documentos sustentatorios',
-      'Evaluación por subdirección académica',
-      'Emisión de resolución',
-      'Notificación al estudiante',
-    ],
-  },
-];
+  return collection.map((entry) => ({
+    ...entry.data,
+    id: entry.data.id ?? entry.id,
+  })) as Documento[];
+}
 
-// --- SUSTENTACIONES ---
-export const sustentaciones: Sustentacion[] = [
-  {
-    id: 'sus-001',
-    tesista: 'Mg. Juan Carlos Pérez López',
-    titulo: 'Impacto de las políticas públicas en el desarrollo sostenible de la región Loreto',
-    programa: 'Doctorado en Gestión Pública',
-    fecha: '2025-02-15',
-    hora: '10:00',
-    lugar: 'Auditorio Principal - EPG',
-    jurados: [
-      'Dr. Fernando Castillo Mendoza (Presidente)',
-      'Dra. Patricia Vargas Lozano',
-      'Dr. Carlos Mendoza Ríos',
-    ],
-    asesor: 'Dr. Roberto Sánchez Torres',
-    tipo: 'tesis',
-  },
-  {
-    id: 'sus-002',
-    tesista: 'Bach. María Elena García Ruiz',
-    titulo: 'Estrategias didácticas innovadoras para la enseñanza virtual en educación superior',
-    programa: 'Maestría en Educación',
-    fecha: '2025-02-18',
-    hora: '15:00',
-    lugar: 'Sala de Sustentaciones B',
-    jurados: [
-      'Dra. Lucía Ramírez Delgado (Presidenta)',
-      'Dr. Roberto Sánchez Torres',
-      'Mg. Elena Torres Campos',
-    ],
-    asesor: 'Dra. Lucía Ramírez Delgado',
-    tipo: 'tesis',
-  },
-  {
-    id: 'sus-003',
-    tesista: 'Bach. Pedro Martínez Vásquez',
-    titulo: 'Evaluación del impacto ambiental de la minería ilegal en la cuenca del río Nanay',
-    programa: 'Maestría en Ingeniería Ambiental',
-    fecha: '2025-02-20',
-    hora: '11:00',
-    lugar: 'Auditorio Principal - EPG',
-    jurados: [
-      'Dr. José Luis Vásquez Fernández (Presidente)',
-      'Dr. Miguel Ángel Paredes Ruiz',
-      'Mg. Ana María Quispe Rodríguez',
-    ],
-    asesor: 'Dr. Miguel Ángel Paredes Ruiz',
-    tipo: 'tesis',
-  },
-];
+export async function getDocumentosByTipo(
+  tipo: Documento['tipo'],
+): Promise<Documento[]> {
+  const documentos = await getDocumentosInstitucionales();
+  return documentos.filter((d) => d.tipo === tipo);
+}
 
-// --- INFORMACIÓN INSTITUCIONAL ---
-export const infoInstitucional = {
-  nombreCompleto: 'Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana',
-  nombreCorto: 'EPG-UNAP',
-  lema: 'Formando líderes para el desarrollo de la Amazonía',
-  historia: `La Escuela de Postgrado de la Universidad Nacional de la Amazonía Peruana fue creada en 1990, con la misión de formar profesionales de alto nivel académico comprometidos con el desarrollo sostenible de la región amazónica.
+export async function getReglamentos(): Promise<Documento[]> {
+  return getDocumentosByTipo('reglamento');
+}
 
-A lo largo de más de tres décadas, hemos graduado a miles de profesionales que hoy ocupan cargos de liderazgo en instituciones públicas y privadas, contribuyendo significativamente al desarrollo de nuestra región y del país.
+export async function getFormatos(): Promise<Documento[]> {
+  return getDocumentosByTipo('formato');
+}
 
-Nuestra oferta académica ha evolucionado para responder a las demandas del mercado laboral y las necesidades de desarrollo regional, incorporando programas innovadores en áreas estratégicas como gestión pública, derecho, educación, salud pública y ciencias ambientales.`,
-  mision: 'Formar profesionales de postgrado con excelencia académica, competencias investigativas y compromiso ético, capaces de generar conocimiento y liderar procesos de transformación para el desarrollo sostenible de la Amazonía peruana.',
-  vision: 'Ser una Escuela de Postgrado líder en la formación de profesionales e investigadores de alto nivel en la Amazonía, reconocida nacional e internacionalmente por la calidad de sus programas, la producción científica de su comunidad académica y su contribución al desarrollo regional.',
-  valores: [
-    'Excelencia académica',
-    'Integridad y ética',
-    'Innovación e investigación',
-    'Responsabilidad social',
-    'Respeto a la diversidad',
-    'Compromiso con la Amazonía',
-  ],
-};
+export async function getGuias(): Promise<Documento[]> {
+  return getDocumentosByTipo('guia');
+}
 
-// Helpers
-export const getDocumentosByTipo = (tipo: Documento['tipo']) => documentos.filter(d => d.tipo === tipo);
-export const getReglamentos = () => getDocumentosByTipo('reglamento');
-export const getFormatos = () => getDocumentosByTipo('formato');
-export const getGuias = () => getDocumentosByTipo('guia');
-export const getManuales = () => getDocumentosByTipo('manual');
-export const getSustentacionesProximas = () => {
-  const hoy = new Date();
-  return sustentaciones
-    .filter(s => new Date(s.fecha) >= hoy)
-    .sort((a, b) => new Date(a.fecha).getTime() - new Date(b.fecha).getTime());
-};
+export async function getManuales(): Promise<Documento[]> {
+  return getDocumentosByTipo('manual');
+}

--- a/src/features/admision/components/AdmisionContent.tsx
+++ b/src/features/admision/components/AdmisionContent.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { convocatorias, fechasImportantes } from '@/data/convocatorias'
-import { contactoAdmision, getEmailHref } from '@/data/contacto'
+import { getEmailHref } from '@/lib/contact-helpers'
 import type { Programa } from '@/types/programas'
+import type { Convocatoria, FechaImportante, InfoContacto } from '@/types'
 import { formatShortDate } from '@/lib/formatters'
 import {
   tipoFechaAdmisionColors,
@@ -45,7 +45,7 @@ import { IconCircle } from '@/components/ui/icon-circle'
 // ========================================
 // TIMELINE COMPONENT
 // ========================================
-function Timeline() {
+function Timeline({ fechasImportantes }: { fechasImportantes: FechaImportante[] }) {
   const fechasProximas = fechasImportantes
     .filter((f) => new Date(f.fecha) >= new Date('2026-01-01'))
     .sort((a, b) => new Date(a.fecha).getTime() - new Date(b.fecha).getTime())
@@ -215,7 +215,7 @@ function ProcesoAdmision() {
 // ========================================
 // REQUISITOS COMPONENT
 // ========================================
-function Requisitos() {
+function Requisitos({ convocatorias }: { convocatorias: Convocatoria[] }) {
   const [tipoSeleccionado, setTipoSeleccionado] = useState<
     'maestria' | 'doctorado'
   >('maestria')
@@ -608,7 +608,17 @@ function ProgramasVacantes({ programas }: { programas: Programa[] }) {
 // ========================================
 // MAIN EXPORT COMPONENT
 // ========================================
-export function AdmisionContent({ programas }: { programas: Programa[] }) {
+export function AdmisionContent({
+  programas,
+  convocatorias,
+  fechasImportantes,
+  contactoAdmision,
+}: {
+  programas: Programa[]
+  convocatorias: Convocatoria[]
+  fechasImportantes: FechaImportante[]
+  contactoAdmision: InfoContacto
+}) {
   return (
     <div className="space-y-16">
       {/* Timeline */}
@@ -622,7 +632,7 @@ export function AdmisionContent({ programas }: { programas: Programa[] }) {
           description="Conoce las fechas clave del proceso de admisión 2026-I"
         />
         <Card className="p-6">
-          <Timeline />
+          <Timeline fechasImportantes={fechasImportantes} />
         </Card>
       </section>
 
@@ -670,7 +680,7 @@ export function AdmisionContent({ programas }: { programas: Programa[] }) {
           title="Requisitos de Admisión"
           description="Prepara la documentación necesaria para tu inscripción"
         />
-        <Requisitos />
+        <Requisitos convocatorias={convocatorias} />
       </section>
 
       {/* Costos */}

--- a/src/features/escuela/components/EscuelaContent.tsx
+++ b/src/features/escuela/components/EscuelaContent.tsx
@@ -5,18 +5,30 @@ import {
   MisionVisionSection,
   ValoresSection,
 } from './sections'
+import type { Documento, Estadistica, InfoInstitucional } from '@/types'
 
 // ========================================
 // MAIN EXPORT COMPONENT
 // ========================================
-export function EscuelaContent() {
+export function EscuelaContent({
+  infoInstitucional,
+  estadisticasInstitucionales,
+  documentos,
+}: {
+  infoInstitucional: InfoInstitucional
+  estadisticasInstitucionales: Estadistica[]
+  documentos: Documento[]
+}) {
   return (
     <div className="space-y-16">
-      <HistoriaSection />
-      <MisionVisionSection />
+      <HistoriaSection
+        infoInstitucional={infoInstitucional}
+        estadisticasInstitucionales={estadisticasInstitucionales}
+      />
+      <MisionVisionSection infoInstitucional={infoInstitucional} />
       <ValoresSection />
-      <EstadisticasSection />
-      <DocumentosSection />
+      <EstadisticasSection estadisticasInstitucionales={estadisticasInstitucionales} />
+      <DocumentosSection documentos={documentos} />
     </div>
   )
 }

--- a/src/features/escuela/components/sections/DocumentosSection.tsx
+++ b/src/features/escuela/components/sections/DocumentosSection.tsx
@@ -1,6 +1,6 @@
-import { documentos } from '@/data/institucional'
 import { DocumentDownloadItem } from '@/components/ui/document-download-item'
 import { SectionHeader } from '@/components/ui/section-header'
+import type { Documento } from '@/types'
 import {
   Card,
   CardContent,
@@ -10,7 +10,11 @@ import {
 } from '@/components/ui/card'
 import { BookOpen, FileText } from 'lucide-react'
 
-export function DocumentosSection() {
+export function DocumentosSection({
+  documentos,
+}: {
+  documentos: Documento[]
+}) {
   const reglamentos = documentos.filter((documento) => documento.tipo === 'reglamento')
   const formatos = documentos.filter((documento) => documento.tipo === 'formato')
   const guias = documentos.filter(

--- a/src/features/escuela/components/sections/EstadisticasSection.tsx
+++ b/src/features/escuela/components/sections/EstadisticasSection.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react'
-import { estadisticasInstitucionales } from '@/data/estadisticas'
 import { StatItem } from '@/components/ui/stat-item'
 import { SectionHeader } from '@/components/ui/section-header'
 import { IconCircle } from '@/components/ui/icon-circle'
+import type { Estadistica } from '@/types'
 import {
   Award,
   BookOpen,
@@ -21,7 +21,11 @@ const iconMap: Record<string, ReactNode> = {
   ThumbsUp: <Heart className="h-8 w-8" />,
 }
 
-export function EstadisticasSection() {
+export function EstadisticasSection({
+  estadisticasInstitucionales,
+}: {
+  estadisticasInstitucionales: Estadistica[]
+}) {
   return (
     <section id="estadisticas">
       <SectionHeader

--- a/src/features/escuela/components/sections/HistoriaSection.tsx
+++ b/src/features/escuela/components/sections/HistoriaSection.tsx
@@ -1,11 +1,16 @@
-import { infoInstitucional } from '@/data/institucional'
-import { estadisticasInstitucionales } from '@/data/estadisticas'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Building2 } from 'lucide-react'
+import type { Estadistica, InfoInstitucional } from '@/types'
 
-export function HistoriaSection() {
+export function HistoriaSection({
+  infoInstitucional,
+  estadisticasInstitucionales,
+}: {
+  infoInstitucional: InfoInstitucional
+  estadisticasInstitucionales: Estadistica[]
+}) {
   const destacados = estadisticasInstitucionales.slice(0, 4)
 
   return (

--- a/src/features/escuela/components/sections/MisionVisionSection.tsx
+++ b/src/features/escuela/components/sections/MisionVisionSection.tsx
@@ -1,9 +1,13 @@
-import { infoInstitucional } from '@/data/institucional'
 import { SectionHeader } from '@/components/ui/section-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Eye, Target } from 'lucide-react'
+import type { InfoInstitucional } from '@/types'
 
-export function MisionVisionSection() {
+export function MisionVisionSection({
+  infoInstitucional,
+}: {
+  infoInstitucional: InfoInstitucional
+}) {
   return (
     <section id="mision-vision">
       <SectionHeader

--- a/src/features/home/components/AdmissionCTA.astro
+++ b/src/features/home/components/AdmissionCTA.astro
@@ -8,12 +8,13 @@ import {
   getProcesoActual,
   getTextoEstado,
 } from '@/data/admision';
-import { contactoAdmision } from '@/data/contacto';
+import { getContactoAdmision } from '@/data/contacto';
 import { ArrowRight, Calendar, FileText, Phone } from 'lucide-react';
 
 const proceso = await getProcesoActual();
 const estado = proceso ? calcularEstadoProceso(proceso) : 'cerrada';
 const convocatoriaAbierta = await estaConvocatoriaAbierta();
+const contactoAdmision = await getContactoAdmision();
 
 const badgeClass = convocatoriaAbierta
   ? 'bg-epg-navy text-white'

--- a/src/features/home/components/ContactSection.tsx
+++ b/src/features/home/components/ContactSection.tsx
@@ -3,7 +3,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { FormInput } from '@/components/ui/form-input';
 import { SectionHeader } from '@/components/ui/section-header';
 import { Separator } from '@/components/ui/separator';
-import { contactoGeneral, getWhatsappHref } from '@/data/contacto';
+import { getWhatsappHref } from '@/lib/contact-helpers';
+import type { InfoContacto } from '@/types';
 
 import {
   CheckCircle,
@@ -35,33 +36,35 @@ const asuntoOptions = [
   { value: 'otro', label: 'Otro' },
 ];
 
-const contactInfo = [
-  {
-    icon: MapPin,
-    label: 'Dirección',
-    value: contactoGeneral.direccion,
-    href: `https://www.google.com/maps?q=${contactoGeneral.coordenadas?.lat},${contactoGeneral.coordenadas?.lng}`,
-  },
-  {
-    icon: Phone,
-    label: 'Teléfono',
-    value: contactoGeneral.telefonoDisplay,
-    href: `tel:${contactoGeneral.telefono}`,
-  },
-  {
-    icon: Mail,
-    label: 'Correo',
-    value: contactoGeneral.email,
-    href: `mailto:${contactoGeneral.email}`,
-  },
-  {
-    icon: Clock,
-    label: 'Horario',
-    value: contactoGeneral.horarioAtencion,
-  },
-];
+export const ContactSection: React.FC<{ contactoGeneral: InfoContacto }> = ({
+  contactoGeneral,
+}) => {
+  const contactInfo = [
+    {
+      icon: MapPin,
+      label: 'Dirección',
+      value: contactoGeneral.direccion,
+      href: `https://www.google.com/maps?q=${contactoGeneral.coordenadas?.lat},${contactoGeneral.coordenadas?.lng}`,
+    },
+    {
+      icon: Phone,
+      label: 'Teléfono',
+      value: contactoGeneral.telefonoDisplay,
+      href: `tel:${contactoGeneral.telefono}`,
+    },
+    {
+      icon: Mail,
+      label: 'Correo',
+      value: contactoGeneral.email,
+      href: `mailto:${contactoGeneral.email}`,
+    },
+    {
+      icon: Clock,
+      label: 'Horario',
+      value: contactoGeneral.horarioAtencion,
+    },
+  ];
 
-export const ContactSection: React.FC = () => {
   const [formData, setFormData] = useState<FormData>({
     nombre: '',
     email: '',

--- a/src/features/home/components/ProgramSearchWithStats.tsx
+++ b/src/features/home/components/ProgramSearchWithStats.tsx
@@ -1,11 +1,10 @@
 import { IconCircle } from '@/components/ui/icon-circle';
 import { StatItem } from '@/components/ui/stat-item';
-import { busquedasPopulares, getBusquedaUrl } from '@/data/busquedas-populares';
-import { estadisticasInstitucionales } from '@/data/estadisticas';
+import { getBusquedaUrl } from '@/lib/busquedas-helpers';
 
 import { getProgramTypeConfig } from '@/lib/config';
 
-import type { Programa } from '@/types';
+import type { BusquedaPopular, Estadistica, Programa } from '@/types';
 import type { LucideIcon } from 'lucide-react';
 import {
   ArrowRight,
@@ -35,7 +34,11 @@ const iconMap: Record<string, LucideIcon> = {
   ThumbsUp,
 };
 
-export const ProgramSearchWithStats: React.FC<{ programas: Programa[] }> = ({ programas }) => {
+export const ProgramSearchWithStats: React.FC<{
+  programas: Programa[];
+  busquedasPopulares: BusquedaPopular[];
+  estadisticasInstitucionales: Estadistica[];
+}> = ({ programas, busquedasPopulares, estadisticasInstitucionales }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedType, setSelectedType] = useState('all');
   const [suggestions, setSuggestions] = useState<Programa[]>([]);

--- a/src/features/home/components/StatsSection.tsx
+++ b/src/features/home/components/StatsSection.tsx
@@ -1,6 +1,6 @@
 import { IconCircle } from '@/components/ui/icon-circle';
 import { StatItem } from '@/components/ui/stat-item';
-import { estadisticasInstitucionales } from '@/data/estadisticas';
+import type { Estadistica } from '@/types';
 import type { LucideIcon } from 'lucide-react';
 import {
   Award,
@@ -22,7 +22,9 @@ const iconMap: Record<string, LucideIcon> = {
   ThumbsUp,
 };
 
-export const StatsSection: React.FC = () => {
+export const StatsSection: React.FC<{
+  estadisticasInstitucionales: Estadistica[];
+}> = ({ estadisticasInstitucionales }) => {
   return (
     <section className="home-section px-4 sm:px-6 lg:px-8 bg-epg-navy-dark relative overflow-hidden">
       {/* Decorative elements */}

--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -1,6 +1,5 @@
 ---
 // Footer.astro — Pure Astro component, zero client-side JS
-import { contactoGeneral } from '@/data/contacto';
 import {
   Clock,
   Facebook,
@@ -12,6 +11,13 @@ import {
   Twitter,
   Youtube,
 } from 'lucide-react';
+import type { InfoContacto } from '@/types';
+
+interface Props {
+  contactoGeneral: InfoContacto;
+}
+
+const { contactoGeneral } = Astro.props as Props;
 
 const footerLinks = {
   programas: [

--- a/src/features/servicios/components/ServiciosGrid.tsx
+++ b/src/features/servicios/components/ServiciosGrid.tsx
@@ -1,4 +1,3 @@
-import { contactoSoporte } from '@/data/contacto'
 import { LinkArrow } from '@/components/ui/link-arrow'
 import {
   GraduationCap,
@@ -43,8 +42,15 @@ const gradientColors = [
 ]
 
 import type { Servicio } from '@/types'
+import type { InfoContacto } from '@/types'
 
-export function ServiciosGrid({ servicios }: { servicios: Servicio[] }) {
+export function ServiciosGrid({
+  servicios,
+  contactoSoporte,
+}: {
+  servicios: Servicio[]
+  contactoSoporte: InfoContacto
+}) {
   return (
     <div className="space-y-12">
       {/* Grid de Servicios */}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,6 +12,7 @@ import ScrollToTop from "../components/ui/ScrollToTop.astro";
 import { FloatingContactButton } from "../components/ui/floating-contact-button";
 import { ErrorBoundary } from "../components/ui/error-boundary";
 import { ClientRouter } from "astro:transitions";
+import { getContactoGeneral } from "../data/contacto";
 
 interface Props {
 	title?: string;
@@ -56,6 +57,7 @@ const imageURL = image.startsWith("http") ? image : new URL(image, siteUrl).href
 
 // Keywords as string
 const keywordsString = keywords.join(", ");
+const contactoGeneral = await getContactoGeneral();
 ---
 
 <!doctype html>
@@ -152,7 +154,7 @@ const keywordsString = keywords.join(", ");
 	</head>
 	<body class="min-h-screen bg-background flex flex-col">
 		<slot />
-		<Footer />
+		<Footer contactoGeneral={contactoGeneral} />
 		<ScrollToTop />
 		<ErrorBoundary client:load>
 			<FloatingContactButton />

--- a/src/lib/busquedas-helpers.ts
+++ b/src/lib/busquedas-helpers.ts
@@ -1,0 +1,12 @@
+import type { BusquedaPopular } from '@/types';
+
+export function getBusquedaUrl(busqueda: BusquedaPopular): string {
+  const params = new URLSearchParams();
+  params.set('q', busqueda.query);
+
+  if (busqueda.tipo) {
+    params.set('tipo', busqueda.tipo);
+  }
+
+  return `/programas?${params.toString()}`;
+}

--- a/src/lib/contact-helpers.ts
+++ b/src/lib/contact-helpers.ts
@@ -1,0 +1,13 @@
+export function getTelefonoHref(telefono: string): string {
+  return `tel:${telefono}`;
+}
+
+export function getEmailHref(email: string): string {
+  return `mailto:${email}`;
+}
+
+export function getWhatsappHref(whatsapp: string, mensaje?: string): string {
+  const numero = whatsapp.replace(/\D/g, '');
+  const texto = mensaje ? `?text=${encodeURIComponent(mensaje)}` : '';
+  return `https://wa.me/${numero}${texto}`;
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,9 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../features/navigation/components/Navbar.astro';
-import { contactoGeneral } from '../data/contacto';
+import { getContactoGeneral } from '../data/contacto';
+
+const contactoGeneral = await getContactoGeneral();
 ---
 
 <Layout 

--- a/src/pages/admision/index.astro
+++ b/src/pages/admision/index.astro
@@ -3,9 +3,14 @@ import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';
 import { AdmisionContent } from '../../features/admision';
 import { getProgramas } from '../../data/programas';
+import { getConvocatorias, getFechasImportantesAdmision } from '../../data/convocatorias';
+import { getContactoAdmision } from '../../data/contacto';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
 
 const programas = await getProgramas();
+const convocatorias = await getConvocatorias();
+const fechasImportantes = await getFechasImportantesAdmision();
+const contactoAdmision = await getContactoAdmision();
 ---
 
 <Layout 
@@ -178,7 +183,13 @@ const programas = await getProgramas();
       <section class="py-16 bg-gray-50">
         <div class="container-main">
         <ErrorBoundary client:load>
-          <AdmisionContent client:load programas={programas} />
+          <AdmisionContent
+            client:load
+            programas={programas}
+            convocatorias={convocatorias}
+            fechasImportantes={fechasImportantes}
+            contactoAdmision={contactoAdmision}
+          />
         </ErrorBoundary>
         </div>
       </section>

--- a/src/pages/contacto/index.astro
+++ b/src/pages/contacto/index.astro
@@ -2,9 +2,11 @@
 import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';
 import { ContactForm } from '../../features/contacto';
-import { contactoGeneral } from '../../data/contacto';
+import { getContactoGeneral } from '../../data/contacto';
 import { FORMSPREE_ID } from 'astro:env/server';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+
+const contactoGeneral = await getContactoGeneral();
 ---
 
 <Layout 

--- a/src/pages/escuela/documentos.astro
+++ b/src/pages/escuela/documentos.astro
@@ -2,10 +2,13 @@
 import EscuelaLayout from '../../layouts/EscuelaLayout.astro';
 import { DocumentosSection } from '../../features/escuela';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+import { getDocumentosInstitucionales } from '../../data/institucional';
+
+const documentos = await getDocumentosInstitucionales();
 ---
 
 <EscuelaLayout activeTab="/escuela/documentos">
   <ErrorBoundary client:load>
-    <DocumentosSection client:load />
+    <DocumentosSection client:load documentos={documentos} />
   </ErrorBoundary>
 </EscuelaLayout>

--- a/src/pages/escuela/estadisticas.astro
+++ b/src/pages/escuela/estadisticas.astro
@@ -2,10 +2,16 @@
 import EscuelaLayout from '../../layouts/EscuelaLayout.astro';
 import { EstadisticasSection } from '../../features/escuela';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+import { getEstadisticasInstitucionales } from '../../data/estadisticas';
+
+const estadisticasInstitucionales = await getEstadisticasInstitucionales();
 ---
 
 <EscuelaLayout activeTab="/escuela/estadisticas">
   <ErrorBoundary client:load>
-    <EstadisticasSection client:load />
+    <EstadisticasSection
+      client:load
+      estadisticasInstitucionales={estadisticasInstitucionales}
+    />
   </ErrorBoundary>
 </EscuelaLayout>

--- a/src/pages/escuela/historia.astro
+++ b/src/pages/escuela/historia.astro
@@ -2,10 +2,19 @@
 import EscuelaLayout from '../../layouts/EscuelaLayout.astro';
 import { HistoriaSection } from '../../features/escuela';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+import { getInfoInstitucional } from '../../data/institucional';
+import { getEstadisticasInstitucionales } from '../../data/estadisticas';
+
+const infoInstitucional = await getInfoInstitucional();
+const estadisticasInstitucionales = await getEstadisticasInstitucionales();
 ---
 
 <EscuelaLayout activeTab="/escuela/historia">
   <ErrorBoundary client:load>
-    <HistoriaSection client:load />
+    <HistoriaSection
+      client:load
+      infoInstitucional={infoInstitucional}
+      estadisticasInstitucionales={estadisticasInstitucionales}
+    />
   </ErrorBoundary>
 </EscuelaLayout>

--- a/src/pages/escuela/mision-vision.astro
+++ b/src/pages/escuela/mision-vision.astro
@@ -2,10 +2,16 @@
 import EscuelaLayout from '../../layouts/EscuelaLayout.astro';
 import { MisionVisionSection } from '../../features/escuela';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+import { getInfoInstitucional } from '../../data/institucional';
+
+const infoInstitucional = await getInfoInstitucional();
 ---
 
 <EscuelaLayout activeTab="/escuela/mision-vision">
   <ErrorBoundary client:load>
-    <MisionVisionSection client:load />
+    <MisionVisionSection
+      client:load
+      infoInstitucional={infoInstitucional}
+    />
   </ErrorBoundary>
 </EscuelaLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,8 @@ import {
 } from '../features/home';
 import { getFeaturedPrograms } from '../lib/api';
 import { getProgramas } from '../data/programas';
+import { getBusquedasPopulares } from '../data/busquedas-populares';
+import { getEstadisticasInstitucionales } from '../data/estadisticas';
 import type { ApiProgram } from '../lib/api/programs/types';
 import { ErrorBoundary } from '../components/ui/error-boundary';
 
@@ -16,6 +18,8 @@ import { ErrorBoundary } from '../components/ui/error-boundary';
 let apiPrograms: ApiProgram[] = [];
 let hasError = false;
 const programas = await getProgramas();
+const busquedasPopulares = await getBusquedasPopulares();
+const estadisticasInstitucionales = await getEstadisticasInstitucionales();
 
 try {
   apiPrograms = await getFeaturedPrograms();
@@ -53,7 +57,12 @@ const formacionContinuaCount = 0; // La API no tiene este tipo aún
     
     <!-- Búsqueda de Programas + Estadísticas — React, hydrates when visible -->
     <ErrorBoundary client:load>
-      <ProgramSearchWithStats client:visible programas={programas} />
+      <ProgramSearchWithStats
+        client:visible
+        programas={programas}
+        busquedasPopulares={busquedasPopulares}
+        estadisticasInstitucionales={estadisticasInstitucionales}
+      />
     </ErrorBoundary>
     
     <!-- CTA de Admisión — Astro component, zero JS -->

--- a/src/pages/servicios/index.astro
+++ b/src/pages/servicios/index.astro
@@ -4,8 +4,10 @@ import Navbar from '../../features/navigation/components/Navbar.astro';
 import { ServiciosGrid } from '../../features/servicios';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
 import { getServicios } from '../../data/servicios';
+import { getContactoSoporte } from '../../data/contacto';
 
 const servicios = await getServicios();
+const contactoSoporte = await getContactoSoporte();
 ---
 
 <Layout 
@@ -30,7 +32,11 @@ const servicios = await getServicios();
     <section class="py-12 bg-gray-50">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <ErrorBoundary client:load>
-          <ServiciosGrid client:load servicios={servicios} />
+          <ServiciosGrid
+            client:load
+            servicios={servicios}
+            contactoSoporte={contactoSoporte}
+          />
         </ErrorBoundary>
       </div>
     </section>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,7 @@ export type {
   InfoContacto,
   RedSocial,
   Documento,
+  InfoInstitucional,
 } from './institucional';
 
 // Navegación

--- a/src/types/institucional.ts
+++ b/src/types/institucional.ts
@@ -56,3 +56,13 @@ export interface Documento {
   tipo: 'reglamento' | 'formato' | 'manual' | 'guia';
   fechaActualizacion?: string;
 }
+
+export interface InfoInstitucional {
+  nombreCompleto: string;
+  nombreCorto: string;
+  lema: string;
+  historia: string;
+  mision: string;
+  vision: string;
+  valores: string[];
+}


### PR DESCRIPTION
## Summary
- Migrates remaining legacy data modules (`contacto`, `busquedas-populares`, `estadisticas`, `convocatorias`, `institucional`) to Astro Content Collections and replaces hardcoded arrays with `getCollection/getEntry` accessors.
- Adds dedicated seeders and generated JSON content for these collections, and registers all new schemas in `src/content/config.ts`.
- Refactors pages/components to fetch collection data in `.astro` files and pass typed props to client components; also moves client-safe helpers to `src/lib` to avoid server-only import issues.

## Validation
- `pnpm run seed`
- `pnpm tsc --noEmit`
- `pnpm run build`