### PR TITLE
fix: prevent estudiantes hero overlap with fixed navbar (#270)

### DIFF
--- a/src/pages/estudiantes/index.astro
+++ b/src/pages/estudiantes/index.astro
@@ -27,7 +27,7 @@ const faq = await getPreguntasFrecuentes();
   keywords={["portal estudiante UNAP", "trámites postgrado", "SIGAE EPG", "aula virtual maestría", "estudiantes postgrado Iquitos"]}
 >
   <Navbar />
-  <main class="min-h-screen">
+  <main class="min-h-screen pt-16 md:pt-[108px]">
     <ErrorBoundary client:load>
       <EstudiantesContent 
         client:load 


### PR DESCRIPTION
## Summary
- Fixes overlap of the Estudiantes hero section with the fixed header/navigation.
- Adds top padding to the Estudiantes page main container to account for navbar heights in mobile and desktop.
- Keeps scope minimal to avoid side effects in shared UI components.

## Validation
- `pnpm tsc --noEmit`
- `pnpm run build`

Closes #270