### PR TITLE
fix: avoid escuela redirect interstitial in navigation (#277)

### DIFF
--- a/src/features/navigation/components/Footer.astro
+++ b/src/features/navigation/components/Footer.astro
@@ -27,7 +27,7 @@ const footerLinks = {
     { label: 'Cursos', href: '/programas' },
   ],
   laEscuela: [
-    { label: 'Presentación', href: '/escuela' },
+    { label: 'Presentación', href: '/escuela/historia' },
     { label: 'Autoridades', href: '/escuela/autoridades' },
     { label: 'Directorio', href: '/escuela/documentos' },
     { label: 'Contacto', href: '/contacto' },

--- a/src/features/navigation/components/Navbar.astro
+++ b/src/features/navigation/components/Navbar.astro
@@ -35,7 +35,7 @@ const isActivePath = (href: string) => {
 
 const mainNavItems: NavItem[] = [
   { label: 'Inicio', href: '/' },
-  { label: 'La Escuela', href: '/escuela' },
+  { label: 'La Escuela', href: '/escuela/historia' },
   { label: 'Admisión', href: '/admision' },
   { label: 'Programas', href: '/programas' },
   { label: 'Contacto', href: '/contacto' },


### PR DESCRIPTION
## Summary
- Updates main navigation link for **La Escuela** to point directly to `/escuela/historia`.
- Updates footer **Presentación** link to point directly to `/escuela/historia`.
- Prevents users from seeing the intermediary `Redirecting from /escuela/ to /escuela/historia` screen when navigating from site links.

## Validation
- `pnpm tsc --noEmit`
- `pnpm run build`

Closes #277