### PR TITLE
fix: error de build en Windows por symlinks (EPERM) en adapter Vercel (#284)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,9 +6,13 @@ import tailwindcss from '@tailwindcss/vite';
 
 import vercel from '@astrojs/vercel';
 
+const isVercel = process.env.VERCEL === '1';
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://epg.unapiquitos.edu.pe',
+
+  output: isVercel ? undefined : 'static',
 
   env: {
     schema: {
@@ -50,5 +54,5 @@ export default defineConfig({
     plugins: [tailwindcss()]
   },
 
-  adapter: vercel()
+  adapter: isVercel ? vercel() : undefined,
 });

--- a/src/pages/programas/[slug].astro
+++ b/src/pages/programas/[slug].astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = false;
+export const prerender = !process.env.VERCEL;
 
 import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';
@@ -9,6 +9,14 @@ import { getProgramBySlug } from '../../lib/api/programs';
 import { mapApiProgramToPrograma } from '../../lib/program-mappers';
 import type { Programa } from '../../types/programas';
 import { ErrorBoundary } from '../../components/ui/error-boundary';
+import { getProgramas } from '../../data/programas';
+
+export async function getStaticPaths() {
+  const programas = await getProgramas();
+  return programas.map((p) => ({
+    params: { slug: p.slug ?? p.id },
+  }));
+}
 
 const { slug } = Astro.params;
 let programaData: Programa | undefined = slug ? await getProgramaBySlug(slug) : undefined;

--- a/src/pages/programas/index.astro
+++ b/src/pages/programas/index.astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = false;
+export const prerender = !process.env.VERCEL;
 
 import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../features/navigation/components/Navbar.astro';


### PR DESCRIPTION
Closes #284

## Descripción

Al ejecutar pnpm build en Windows, el build fallaba con un error EPERM: operation not permitted, symlink debido a que el adapter @astrojs/vercel intenta recrear los junctions (symlinks de Windows) de pnpm en .vercel/output.

## Solución

Se hace el adapter de Vercel condicional a la variable de entorno VERCEL:

- **stro.config.mjs**: dapter: process.env.VERCEL === '1' ? vercel() : undefined y output: 'static' para builds locales.
- **src/pages/programas/index.astro** y **[slug].astro**: prerender = !process.env.VERCEL
- **[slug].astro**: Se agregó getStaticPaths() para generar rutas estáticas localmente.

En producción (Vercel), VERCEL=1 está definido automáticamente, por lo que el comportamiento en deploy es idéntico al anterior.

## Archivos modificados

| Archivo | Cambio |
|---|---|
| stro.config.mjs | Adapter condicional + output: 'static' local |
| src/pages/programas/index.astro | prerender = !process.env.VERCEL |
| src/pages/programas/[slug].astro | prerender condicional + getStaticPaths() |

## Verificación

- pnpm build exitoso localmente (159 páginas, modo static, sin errores)